### PR TITLE
Batch add documents and add UI preview of process

### DIFF
--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -28,8 +28,16 @@ const headers = [
     value: 'name'
   },
   {
-    name: 'Status',
-    value: 'status'
+    name: 'In MeiliSearch',
+    value: 'indexed'
+  },
+  {
+    name: 'Indexing',
+    value: 'isIndexing'
+  },
+  {
+    name: 'Documents',
+    value: 'numberOfDocuments'
   },
   {
     name: 'Hooks',
@@ -41,100 +49,130 @@ const Collections = ({ updateCredentials }) => {
   const [collectionsList, setCollectionsList] = useState([])
   const [updatedCollections, setUpdatedCollections] = useState(false)
   const [needReload, setNeedReload] = useState(false)
+  const [watching, setWatchingCollection] = useState([false])
 
-  const updateStatus = async ({ collection, updateId }) => {
-    if (updateId) {
-      const response = await request(`/${pluginId}/indexes/${collection}/update/${updateId}`, {
+  useEffect(() => {
+    setUpdatedCollections(false)
+  }, [updateCredentials])
+
+  useEffect(() => {
+    if (!updatedCollections) fetchCollections()
+  }, [updatedCollections, updateCredentials])
+
+  // Will start watching a collection (if not already)
+  // For a maximum of 5 enqueued updates in MeiliSearch
+  const watchUpdates = async ({ collection }) => {
+    if (!watching.includes(collection)) {
+      setWatchingCollection(prev => [...prev, collection])
+      const response = await request(`/${pluginId}/indexes/${collection}/update/`, {
         method: 'GET'
       })
-      const { error } = response
-      if (error) errorNotifications(error)
-      else successNotification({ message: `${collection} has all its documents indexed` })
-      setUpdatedCollections(false)
+      if (response.error) errorNotifications(response)
+
+      setWatchingCollection(prev => prev.filter(col => col !== collection))
+      setUpdatedCollections(false) // Ask for up to date data
     }
   }
 
+  // Add collection to MeiliSearch
   const addCollection = async ({ name: collection }) => {
-    const update = await request(`/${pluginId}/collections/${collection}/`, {
+    setCollectionsList(prev => prev.map(col => {
+      if (col.name === collection) return { ...col, indexed: 'Creating..', _isChecked: true }
+      return col
+    }))
+    const response = await request(`/${pluginId}/collections/${collection}`, {
       method: 'POST'
     })
-    if (update.error) {
-      errorNotifications(update)
+    if (response.error) {
+      errorNotifications(response)
     } else {
       successNotification({ message: `${collection} is created!`, duration: 4000 })
-      setCollectionsList(prev => prev.map(col => {
-        if (col.name === collection) col.status = 'enqueued'
-        return col
-      }))
-      updateStatus({ collection, updateId: update.updateId })
+      watchUpdates({ collection }) // start watching
     }
+    setUpdatedCollections(false) // Ask for up to date data
   }
 
+  // Re-indexes all rows from a given collection to MeilISearch
   const updateCollections = async ({ collection }) => {
-    try {
-      const update = await request(`/${pluginId}/collections/${collection}/`, {
-        method: 'PUT'
-      })
-      if (update.error) {
-        errorNotifications(update)
-      } else {
-        successNotification({ message: `${collection} updated!` })
-        setCollectionsList(prev => prev.map(col => {
-          if (col.name === collection) col.status = 'enqueued'
-          return col
-        }))
-        updateStatus({ collection, updateId: update.updateId })
-      }
-    } catch (e) {
-      console.error(e)
+    setCollectionsList(prev => prev.map(col => {
+      if (col.name === collection) return { ...col, indexed: 'Start update...', _isChecked: true }
+      return col
+    }))
+    const response = await request(`/${pluginId}/collections/${collection}/`, {
+      method: 'PUT'
+    })
+    if (response.error) {
+      errorNotifications(response)
+    } else {
+      successNotification({ message: `${collection} update started!` })
+      watchUpdates({ collection }) // start watching
     }
+    setUpdatedCollections(false) // ask for up to date data
   }
 
+  // Remove a collection from MeiliSearch
   const removeCollection = async ({ name: collection }) => {
     const res = await request(`/${pluginId}/indexes/${collection}/`, {
       method: 'DELETE'
     })
     if (res.error) errorNotifications(res)
     else successNotification({ message: `${collection} collection is removed from MeiliSearch!`, duration: 4000 })
+    setUpdatedCollections(false) // ask for up to date data
   }
 
+  // Depending on the checkbox states will eather
+  // - Add the collection to MeiliSearch
+  // - Remove the collection from MeiliSearch
   const addOrRemoveCollection = async (row) => {
     if (row._isChecked) await removeCollection(row)
-    else await addCollection(row)
-    setUpdatedCollections(false)
+    else addCollection(row)
+  }
+
+  // Construct reload status to add in table
+  const constructReloadStatus = (indexed, hooked) => {
+    if ((indexed && !hooked) || (!indexed && hooked)) {
+      return 'Reload needed'
+    } else if (indexed && hooked) {
+      return 'Active'
+    } else {
+      return ''
+    }
+  }
+
+  // Construct verbose table text
+  const constructColRow = (col) => {
+    const { indexed, isIndexing, numberOfDocuments, numberOfRows } = col
+    return {
+      ...col,
+      indexed: indexed ? 'Yes' : 'No',
+      isIndexing: isIndexing ? 'Yes' : 'No',
+      numberOfDocuments: `${numberOfDocuments} / ${numberOfRows}`,
+      hooked: constructReloadStatus(col.indexed, col.hooked),
+      _isChecked: col.indexed
+    }
   }
 
   const fetchCollections = async () => {
     const { collections, error, ...res } = await request(`/${pluginId}/collections/`, {
       method: 'GET'
     })
+
     if (error) errorNotifications(res)
     else {
-      const reloadNeeded = (indexed, hooked) => {
-        if ((indexed && !hooked) || (!indexed && hooked)) {
-          return 'Reload needed'
-        } else if (indexed && hooked) {
-          return 'Active'
-        } else {
-          return ''
-        }
-      }
+      // Start watching collection that are being indexed
+      collections.map(col => col.isIndexing && watchUpdates({ collection: col }))
+      // Create verbose text that will be showed in the table
+      const verboseCols = collections.map(col => constructColRow(col))
+      // Find possible collection that needs a reload to activate its hooks
+      const reloading = verboseCols.find(col => col.hooked === 'Reload needed')
 
-      const colStatus = collections.map(col => (
-        {
-          ...col,
-          status: (col.indexed) ? 'Indexed In MeiliSearch' : 'Not in MeiliSearch',
-          hooked: reloadNeeded(col.indexed, col.hooked),
-          _isChecked: col.indexed
-        }
-      ))
-      const reloading = colStatus.find(col => col.hooked === 'Reload needed')
       setNeedReload(reloading)
-      setCollectionsList(colStatus)
-      setUpdatedCollections(true)
+      setCollectionsList(verboseCols)
+      setUpdatedCollections(true) // Collection information is up to date
     }
   }
 
+  // Reload request
   const reload = async () => {
     try {
       strapi.lockApp({ enabled: true })
@@ -153,14 +191,6 @@ const Collections = ({ updateCredentials }) => {
     }
   }
 
-  useEffect(() => {
-    setUpdatedCollections(false)
-  }, [updateCredentials])
-
-  useEffect(() => {
-    if (!updatedCollections) fetchCollections()
-  }, [updatedCollections, updateCredentials])
-
   return (
       <div className="col-md-12">
           <Wrapper>
@@ -171,6 +201,9 @@ const Collections = ({ updateCredentials }) => {
                 withBulkAction
                 onSelect={(row) => {
                   addOrRemoveCollection(row)
+                }}
+                onClickRow={(e, data) => {
+                  addOrRemoveCollection(data)
                 }}
                 rowLinks={[
                   {

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -160,7 +160,7 @@ const Collections = ({ updateCredentials }) => {
     if (error) errorNotifications(res)
     else {
       // Start watching collection that are being indexed
-      collections.map(col => col.isIndexing && watchUpdates({ collection: col }))
+      collections.map(col => col.isIndexing && watchUpdates({ collection: col.name }))
       // Create verbose text that will be showed in the table
       const verboseCols = collections.map(col => constructColRow(col))
       // Find possible collection that needs a reload to activate its hooks

--- a/config/routes.json
+++ b/config/routes.json
@@ -26,7 +26,7 @@
     },
     {
       "method": "GET",
-      "path": "/indexes/:indexUid/update/:updateId",
+      "path": "/indexes/:indexUid/update",
       "handler": "meilisearch.waitForDocumentsToBeIndexed",
       "config": {
         "policies": []

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -63,7 +63,7 @@ async function waitForDocumentsToBeIndexed (ctx) {
   const credentials = await getCredentials()
   const numberOfDocuments = await meilisearch.http(meilisearch.client(credentials)).waitForPendingUpdates({
     indexUid,
-    updateNbr: 5
+    updateNbr: 2
   })
   return { numberOfDocuments }
 }

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -19,9 +19,9 @@ async function sendCtx (ctx, fct) {
     ctx.send(body)
   } catch (e) {
     console.error(e)
-    const message = (e.type === 'MeiliSearchCommunicationError')
+    const message = (e.name === 'MeiliSearchCommunicationError')
       ? `Could not connect with MeiliSearch ${e.code}`
-      : `${e.type}: \n${e.message || e.code}`
+      : `${e.name}: \n${e.message || e.code}`
     return {
       error: true,
       message,
@@ -59,11 +59,13 @@ async function deleteIndex (ctx) {
 }
 
 async function waitForDocumentsToBeIndexed (ctx) {
-  const { updateId, indexUid } = ctx.params
+  const { indexUid } = ctx.params
   const credentials = await getCredentials()
-  return meilisearch.http(meilisearch.client(credentials)).waitForPendingUpdate({
-    updateId, indexUid
+  const numberOfDocuments = await meilisearch.http(meilisearch.client(credentials)).waitForPendingUpdates({
+    indexUid,
+    updateNbr: 5
   })
+  return { numberOfDocuments }
 }
 
 async function addCredentials (ctx) {
@@ -92,35 +94,46 @@ async function UpdateCollections (ctx) {
   return addCollection(ctx)
 }
 
-async function addCollectionRows (ctx) {
-  const { collection } = ctx.params
-  const { data } = ctx.request.body
+async function indexDocuments ({ documents = [], collection }) {
   const credentials = await getCredentials()
-  if (data.length > 0) {
+  if (documents.length > 0) {
     return meilisearch.http(meilisearch.client(credentials)).addDocuments({
       indexUid: collection,
-      data
-    })
-  } else {
-    return await meilisearch.http(meilisearch.client(credentials)).createIndex({
-      indexUid: collection
+      data: documents
     })
   }
 }
 
-async function fetchCollection (ctx) {
-  const { collection } = ctx.params
+async function fetchRowBatch ({ start, limit, collection }) {
+  return strapi.services[collection].find({ _publicationState: 'preview', _limit: limit, _start: start })
+}
 
-  if (!Object.keys(strapi.services).includes(collection)) {
-    return { error: true, message: 'Collection not found' }
+async function numberOfRowsInCollection ({ collection }) {
+  return strapi.services[collection].count({ _publicationState: 'preview' })
+}
+
+async function batchAddCollection (ctx) {
+  const { collection } = ctx.params
+  const count = await numberOfRowsInCollection({ collection })
+  const BATCH_SIZE = 1000
+  const updateIds = []
+  for (let index = 0; index <= count; index += BATCH_SIZE) {
+    const rows = await fetchRowBatch({ start: index, limit: BATCH_SIZE, collection })
+    const { updateId } = await indexDocuments({ collection, documents: rows })
+    if (updateId) updateIds.push(updateId)
   }
-  const rows = await strapi.services[collection].find({ _publicationState: 'preview' })
-  ctx.request.body = { data: rows }
-  return ctx
+  return { updateIds }
 }
 
 async function addCollection (ctx) {
-  return addCollectionRows(await fetchCollection(ctx))
+  const { collection } = ctx.params
+  const credentials = await getCredentials()
+  // Create collection in MeiliSearch
+  await meilisearch.http(meilisearch.client(credentials)).createIndex({
+    indexUid: collection
+  })
+  batchAddCollection(ctx) // does not wait for add documents requests
+  return { message: 'Index created' }
 }
 
 async function getIndexes () {
@@ -132,18 +145,28 @@ async function getIndexes () {
   }
 }
 
+async function getStats ({ collection }) {
+  const credentials = await getCredentials()
+  return meilisearch.http(meilisearch.client(credentials)).getStats({ indexUid: collection })
+}
+
 async function getCollections () {
   const indexes = await getIndexes()
   const hookedCollections = await getHookedCollections()
-  const collections = Object.keys(strapi.services).map(collection => {
+  const collections = Object.keys(strapi.services).map(async collection => {
     const existInMeilisearch = !!(indexes.find(index => index.name === collection))
-    return {
+    const { numberOfDocuments = 0, isIndexing = false } = (existInMeilisearch) ? await getStats({ collection }) : {}
+    const numberOfRows = await numberOfRowsInCollection({ collection })
+    return ({
       name: collection,
       indexed: existInMeilisearch,
+      isIndexing,
+      numberOfDocuments,
+      numberOfRows,
       hooked: hookedCollections.includes(collection)
-    }
+    })
   })
-  return { collections }
+  return { collections: await Promise.all(collections) }
 }
 
 async function reload (ctx) {
@@ -168,7 +191,7 @@ async function reload (ctx) {
 
 module.exports = {
   getCredentials: async (ctx) => sendCtx(ctx, getCredentials),
-  addCollectionRows: async (ctx) => sendCtx(ctx, addCollectionRows),
+  indexDocuments: async (ctx) => sendCtx(ctx, indexDocuments),
   waitForDocumentsToBeIndexed: async (ctx) => sendCtx(ctx, waitForDocumentsToBeIndexed),
   getIndexes: async (ctx) => sendCtx(ctx, getIndexes),
   getCollections: async (ctx) => sendCtx(ctx, getCollections),
@@ -177,5 +200,6 @@ module.exports = {
   deleteAllIndexes: async (ctx) => sendCtx(ctx, deleteAllIndexes),
   deleteIndex: async (ctx) => sendCtx(ctx, deleteIndex),
   UpdateCollections: async (ctx) => sendCtx(ctx, UpdateCollections),
-  reload: async (ctx) => sendCtx(ctx, reload)
+  reload: async (ctx) => sendCtx(ctx, reload),
+  batchAddCollection: async (ctx) => sendCtx(ctx, batchAddCollection)
 }

--- a/cypress/integration/ui_spec.js
+++ b/cypress/integration/ui_spec.js
@@ -91,15 +91,15 @@ describe('Strapi Login flow', () => {
   it('Add Collections to MeiliSearch', () => {
     clickAndCheckRowContent({
       rowNb: 1,
-      contains: ['Indexed In MeiliSearch', 'Reload needed']
+      contains: ['Yes', 'Reload needed']
     })
     clickAndCheckRowContent({
       rowNb: 2,
-      contains: ['Indexed In MeiliSearch', 'Reload needed']
+      contains: ['Yes', 'Reload needed']
     })
     clickAndCheckRowContent({
       rowNb: 3,
-      contains: ['Indexed In MeiliSearch', 'Reload needed']
+      contains: ['Yes', 'Reload needed']
     })
   })
 
@@ -114,33 +114,33 @@ describe('Strapi Login flow', () => {
 
   it('Check for successfull hooks in develop mode', () => {
     if (env === 'develop' || env === 'watch') {
-      checkCollectionContent({ rowNb: 1, contains: ['Indexed In MeiliSearch', 'Active'] })
-      checkCollectionContent({ rowNb: 2, contains: ['Indexed In MeiliSearch', 'Active'] })
-      checkCollectionContent({ rowNb: 3, contains: ['Indexed In MeiliSearch', 'Active'] })
+      checkCollectionContent({ rowNb: 1, contains: ['Yes', 'Active'] })
+      checkCollectionContent({ rowNb: 2, contains: ['Yes', 'Active'] })
+      checkCollectionContent({ rowNb: 3, contains: ['Yes', 'Active'] })
     } else {
-      checkCollectionContent({ rowNb: 1, contains: ['Indexed In MeiliSearch', 'Reload needed'] })
-      checkCollectionContent({ rowNb: 2, contains: ['Indexed In MeiliSearch', 'Reload needed'] })
-      checkCollectionContent({ rowNb: 3, contains: ['Indexed In MeiliSearch', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 1, contains: ['Yes', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 2, contains: ['Yes', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 3, contains: ['Yes', 'Reload needed'] })
     }
   })
 
   it('Remove Collections from MeiliSearch', () => {
     clickAndCheckRowContent({
       rowNb: 1,
-      contains: ['Not in MeiliSearch']
+      contains: ['No']
     })
     clickAndCheckRowContent({
       rowNb: 2,
-      contains: ['Not in MeiliSearch']
+      contains: ['No']
     })
     clickAndCheckRowContent({
       rowNb: 3,
-      contains: ['Not in MeiliSearch']
+      contains: ['No']
     })
     if (env === 'develop' || env === 'watch') {
-      checkCollectionContent({ rowNb: 1, contains: ['Not in MeiliSearch', 'Reload needed'] })
-      checkCollectionContent({ rowNb: 2, contains: ['Not in MeiliSearch', 'Reload needed'] })
-      checkCollectionContent({ rowNb: 3, contains: ['Not in MeiliSearch', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 1, contains: ['No', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 2, contains: ['No', 'Reload needed'] })
+      checkCollectionContent({ rowNb: 3, contains: ['No', 'Reload needed'] })
     }
   })
 


### PR DESCRIPTION
In this PR: 

fixes: #88 
fixes: #60

### Added information on the UI

![strapi](https://user-images.githubusercontent.com/33010418/114282019-f346fe80-9a41-11eb-9dcd-c0cd88dc6ee5.gif)


- `In MeiliSearch` -> does the collection has an index of the same name in MeiliSearch
- `Indexing` -> are documents being indexed in MeiliSearch
- `Documents` -> number of collection documents already indexed in MeiliSearch
- `Hooks` -> automatic updates in MeiliSearch


### Batching addition

Previously only `100` documents were fetched from Strapi and added to MeiliSearch. 
Now they are fetched 1000 at a time and added to MeiliSearch in the same batch size. 
If there are less than 1000 documents, it still works.

### Watching for updates

Updates are watched 2 at a time. In order to track addition more rapidly in the front end.