### PR TITLE
[Feature/Discussion] Configure the index for a collection to support combined indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">MeiliSearch Strapi Plugin</h1>
-<h1 align="center">Forked by [@MattieBelt](https://github.com/MattieBelt)</h1>
+<h3 align="center">Forked by <a href="https://github.com/MattieBelt">@MattieBelt</a></h3>
 
 <h4 align="center">
   <a href="https://github.com/meilisearch/MeiliSearch">MeiliSearch</a> |
@@ -51,17 +51,17 @@ Inside your Strapi app, add the package:
 
 With `npm`:
 ```bash
-npm install strapi-plugin-meilisearch
+npm install strapi-plugin-meilisearch@npm:@mattiebelt/strapi-plugin-meilisearch
 ```
 
 With `yarn`:
 ```bash
-yarn add strapi-plugin-meilisearch
+yarn add strapi-plugin-meilisearch@npm:@mattiebelt/strapi-plugin-meilisearch
 ```
 
 To apply the plugin to Strapi, a re-build is needed:
 ```bash
-strapi build
+strapi build --clean
 ```
 
 You will need both a running Strapi app and a running MeiliSearch instance. For [specific version compatibility see this section](#-compatibility-with-meilisearch).
@@ -105,7 +105,7 @@ module.exports = () => ({
   //...
   meilisearch: {
     // Your master key
-    api_key: "masterKey",
+    apiKey: "masterKey",
     // Your meili host
     host: "http://localhost:7700",
     // The collections you want to be indexed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 <h1 align="center">MeiliSearch Strapi Plugin</h1>
+<h1 align="center">Forked by [@MattieBelt](https://github.com/MattieBelt)</h1>
 
 <h4 align="center">
   <a href="https://github.com/meilisearch/MeiliSearch">MeiliSearch</a> |
@@ -96,32 +97,23 @@ On the left-navbar, `MeiliSearch` appears under the `PLUGINS` category. If it do
 
 ### 🤫 Add Credentials <!-- omit in toc -->
 
-First, you need to configure credentials via the strapi config, or on the plugin page.
-
-#### Using the plugin page
-
-You can add you MeiliSearch credentials in the upper box of the MeiliSearch plugin page.
-
-For example, using the credentials from the section above: [`Run MeiliSearch`](#-run-meilisearch), the following screen shows where the information should be.
-
-<p align="center">
-<img src="./assets/credentials.png" alt="Add your credentials" width="600"/>
-</p>
-
-Once completed, click on the `add` button.
-
-#### Using a config file
-
-To use the strapi config add the following to `config/plugins.js` or `config/[NODE_ENV]/plugin.js`:
+First, you need to configure credentials via the strapi config.
+Add the following to `config/plugins.js` or `config/[NODE_ENV]/plugin.js` ([docs](https://strapi.io/documentation/developer-docs/latest/setup-deployment-guides/configurations.html#plugins)):
 
 ```js
 module.exports = () => ({
   //...
   meilisearch: {
-    // Your meili host
-    host: "http://localhost:7700",
     // Your master key
     api_key: "masterKey",
+    // Your meili host
+    host: "http://localhost:7700",
+    // The collections you want to be indexed
+    collections: [
+        { name: 'project', index: 'global' }, // `index` is optional
+        { name: 'category' },
+        { name: 'page', index: 'global' }
+      ]
   }
   //...
 })
@@ -131,25 +123,10 @@ Using `config/[NODE_ENV]/plugin.js`, it is possible to have a config file for di
 
 Note that if you use both method, the config file overwrites the credentials added through the plugin page.
 
-
-### 🚛 Add your collections to MeiliSearch <!-- omit in toc -->
-
-If you don't have any collection yet in your Strapi Plugin, please follow [Strapi quickstart](https://strapi.io/documentation/developer-docs/latest/getting-started/quick-start.html).
-
-We will use, as **example**, the collections provided by Strapi's quickstart.
-
-On your plugin homepage, you should have two collections appearing: `restaurant` and `category`.
-
-<p align="center">
-<img src="./assets/collections_indexed.png" alt="Indexed collections need a reload" width="600"/>
-</p>
-
-By clicking on the left checkbox, the collection is automatically indexed in MeiliSearch. For example, if you click on the `restaurant` checkbox, all your restaurants are now available in MeiliSearch. We will see in [start searching](#-start-searching) how to try it out.
-
 ### 🪝 Apply Hooks <!-- omit in toc -->
 
 Hooks are listeners that update MeiliSearch each time you add/update/delete an entry in your collections.
-To activate them, you will have to reload the server. If you are in develop mode, click on the red `Reload Server` button. If not, reload the server manually!
+To will load on a server (re)start.
 
 <p align="center">
 <img src="./assets/no_reload_needed.png" alt="Indexed collections are hooked" width="600"/>

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -106,7 +106,11 @@ const Collections = ({ updateCredentials }) => {
     setCollectionsList(prev =>
       prev.map(col => {
         if (col.name === collection)
-          return { ...col, indexed: `Start update of index: '${col.index}'`, _isChecked: true }
+          return {
+            ...col,
+            indexed: `Start update of index: '${col.index}'`,
+            _isChecked: true,
+          }
         return col
       })
     )

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -223,13 +223,6 @@ const Collections = ({ updateCredentials }) => {
           className="collections"
           headers={headers}
           rows={collectionsList}
-          withBulkAction
-          onSelect={row => {
-            addOrRemoveCollection(row)
-          }}
-          onClickRow={(e, data) => {
-            addOrRemoveCollection(data)
-          }}
           rowLinks={[
             {
               icon: <UpdateButton forwardedAs="span">Update</UpdateButton>,

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -32,8 +32,8 @@ const headers = [
     value: 'indexed',
   },
   {
-    name: 'Indexing',
-    value: 'isIndexing',
+    name: 'Index',
+    value: 'index',
   },
   {
     name: 'Documents',
@@ -106,7 +106,7 @@ const Collections = ({ updateCredentials }) => {
     setCollectionsList(prev =>
       prev.map(col => {
         if (col.name === collection)
-          return { ...col, indexed: 'Start update...', _isChecked: true }
+          return { ...col, indexed: `Start update of index: '${col.index}'`, _isChecked: true }
         return col
       })
     )
@@ -157,11 +157,11 @@ const Collections = ({ updateCredentials }) => {
 
   // Construct verbose table text
   const constructColRow = col => {
-    const { indexed, isIndexing, numberOfDocuments, numberOfRows } = col
+    const { indexed, index, numberOfDocuments, numberOfRows } = col
     return {
       ...col,
       indexed: indexed ? 'Yes' : 'No',
-      isIndexing: isIndexing ? 'Yes' : 'No',
+      index: index,
       numberOfDocuments: `${numberOfDocuments} / ${numberOfRows}`,
       hooked: constructReloadStatus(col.indexed, col.hooked),
       _isChecked: col.indexed,

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -24,20 +24,24 @@ export const ReloadButton = styled(Button)`
 
 const headers = [
   {
-    name: 'Name',
+    name: 'Collection',
     value: 'name',
   },
   {
-    name: 'In MeiliSearch',
-    value: 'indexed',
+    name: 'Documents in index',
+    value: 'numberOfDocuments',
   },
   {
     name: 'Index',
     value: 'index',
   },
   {
-    name: 'Documents',
-    value: 'numberOfDocuments',
+    name: 'Index in MeiliSearch',
+    value: 'indexed',
+  },
+  {
+    name: 'Entries in collection',
+    value: 'numberOfRows',
   },
   {
     name: 'Hooks',
@@ -166,7 +170,8 @@ const Collections = ({ updateCredentials }) => {
       ...col,
       indexed: indexed ? 'Yes' : 'No',
       index: index,
-      numberOfDocuments: `${numberOfDocuments} / ${numberOfRows}`,
+      numberOfDocuments,
+      numberOfRows,
       hooked: constructReloadStatus(col.indexed, col.hooked),
       _isChecked: col.indexed,
     }

--- a/admin/src/components/Credentials.js
+++ b/admin/src/components/Credentials.js
@@ -25,9 +25,9 @@ const Credentials = ({ setUpdatedCredentials }) => {
         }
       )
       setApiKey(apiKey)
-      setconfigFileApiKey(configFileApiKey)
+      setconfigFileApiKey(true)
       setHost(host)
-      setconfigFileHost(configFileHost)
+      setconfigFileHost(true)
     }
     fillMeilisearchCredentials()
     strapi.unlockApp()
@@ -57,7 +57,7 @@ const Credentials = ({ setUpdatedCredentials }) => {
         <Label
           htmlFor="MSHost"
           message={`MeiliSearch Host ${
-            configFileHost ? ' loaded from config file' : ``
+            configFileHost ? ' (loaded from config file)' : ``
           }`}
         />
         <InputText
@@ -74,7 +74,7 @@ const Credentials = ({ setUpdatedCredentials }) => {
         <Label
           htmlFor="MSApiKey"
           message={`MeiliSearch Api Key ${
-            configFileApiKey ? ' loaded from config file' : ''
+            configFileApiKey ? ' (loaded from config file)' : ''
           }`}
         />
         <InputText

--- a/admin/src/pluginId.js
+++ b/admin/src/pluginId.js
@@ -1,4 +1,1 @@
-const pluginPkg = require('../../package.json')
-const pluginId = pluginPkg.name.replace(/^strapi-plugin-/i, '')
-
-module.exports = pluginId
+module.exports = 'meilisearch'

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -30,7 +30,7 @@ async function getCredentials() {
     const apiKey = plugins.meilisearch.apiKey
     const host = plugins.meilisearch.host
 
-    if (!apiKey.length || !host.length) {
+    if (!apiKey || !apiKey.length || !host || !host.length) {
       strapi.log.error('Meilisearch: Could not initialize: apiKey and host must be defined');
     }
 

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -26,17 +26,20 @@ async function getClient(credentials) {
 async function getCredentials() {
   const { plugins } = strapi.config
   if (plugins && plugins.meilisearch) {
-
     const apiKey = plugins.meilisearch.apiKey
     const host = plugins.meilisearch.host
 
     if (!apiKey || !apiKey.length || !host || !host.length) {
-      strapi.log.error('Meilisearch: Could not initialize: apiKey and host must be defined');
+      strapi.log.error(
+        'Meilisearch: Could not initialize: apiKey and host must be defined'
+      )
     }
 
     return { apiKey, host }
   } else {
-    strapi.log.error('Meilisearch: Could not initialize: no plugin config found');
+    strapi.log.error(
+      'Meilisearch: Could not initialize: no plugin config found'
+    )
   }
 }
 
@@ -68,31 +71,36 @@ async function initIndexes() {
       const models = Object.keys(strapi.models)
 
       // Validate the collections from config
-      const validCollections = strapi.config.plugins.meilisearch.collections.filter(({name, index}) => {
-        if(!name) {
-          strapi.log.error('Meilisearch: Invalid config: key `name` must be defined in every collection')
-        } else if (!models.includes(name)) {
-          strapi.log.error(`Meilisearch: Invalid config: Collection: '${name}' is not an existing collection`)
-        } else if (typeof index === 'string' && !index.length) {
-          strapi.log.error(`Meilisearch: Invalid config: \`index\` of collection:'${name}' isn't valid`)
-        } else {
-          return true;
+      const validCollections = strapi.config.plugins.meilisearch.collections.filter(
+        ({ name, index }) => {
+          if (!name) {
+            strapi.log.error(
+              'Meilisearch: Invalid config: key `name` must be defined in every collection'
+            )
+          } else if (!models.includes(name)) {
+            strapi.log.error(
+              `Meilisearch: Invalid config: Collection: '${name}' is not an existing collection`
+            )
+          } else if (typeof index === 'string' && !index.length) {
+            strapi.log.error(
+              `Meilisearch: Invalid config: \`index\` of collection:'${name}' isn't valid`
+            )
+          } else {
+            return true
+          }
         }
-      })
+      )
 
-      validCollections.map((collection) => {
+      validCollections.map(collection => {
         try {
-          client.createIndex({indexUid: collection.index || collection.name});
-        }
-        catch (error) {
-
-        }
+          client.createIndex({ indexUid: collection.index || collection.name })
+        } catch (error) {}
       })
 
       addLifecycles({
         collections: validCollections,
         client,
-      });
+      })
     }
 
     // Add collections to hooked store

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -214,8 +214,6 @@ async function getCollections() {
   const collectionTypes = getCollectionTypes()
   const configuredCollections = strapi.config.plugins.meilisearch.collections.filter(({name, index}) => !(!name || !collectionTypes.includes(name) || (typeof index === 'string' && !index.length)));
 
-  // Combine collectionTypes and configuredCollections into one
-
   const collections = configuredCollections.map(async collection => {
     const existInMeilisearch = !!indexes.find(
       index => index.name === (collection.index || collection.name)

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -41,17 +41,20 @@ async function getHookedCollections() {
 async function getCredentials() {
   const { plugins } = strapi.config
   if (plugins && plugins.meilisearch) {
-
     const apiKey = plugins.meilisearch.apiKey
     const host = plugins.meilisearch.host
 
     if (!apiKey.length || !host.length) {
-      strapi.log.error('Meilisearch: Could not initialize: apiKey and host must be defined');
+      strapi.log.error(
+        'Meilisearch: Could not initialize: apiKey and host must be defined'
+      )
     }
 
     return { apiKey, host }
   } else {
-    strapi.log.error('Meilisearch: Could not initialize: no plugin config found');
+    strapi.log.error(
+      'Meilisearch: Could not initialize: no plugin config found'
+    )
   }
 }
 
@@ -72,7 +75,9 @@ async function deleteIndex(ctx) {
 
 async function waitForDocumentsToBeIndexed(ctx) {
   const { indexUid } = ctx.params
-  const collection = strapi.config.plugins.meilisearch.collections.find(item => item.name === indexUid);
+  const collection = strapi.config.plugins.meilisearch.collections.find(
+    item => item.name === indexUid
+  )
 
   const credentials = await getCredentials()
   const numberOfDocuments = await meilisearch
@@ -105,7 +110,9 @@ async function addCredentials(ctx) {
 
 async function UpdateCollections(ctx) {
   let { collection } = ctx.params
-  collection = strapi.config.plugins.meilisearch.collections.find(item => item.name === collection);
+  collection = strapi.config.plugins.meilisearch.collections.find(
+    item => item.name === collection
+  )
 
   const credentials = await getCredentials()
   const { updateId } = await meilisearch
@@ -154,14 +161,16 @@ async function numberOfRowsInCollection({ collection }) {
 
 async function batchAddCollection(ctx) {
   let { collection } = ctx.params
-  collection = strapi.config.plugins.meilisearch.collections.find(item => item.name === collection);
+  collection = strapi.config.plugins.meilisearch.collections.find(
+    item => item.name === collection
+  )
   const index = collection.index || collection.name
 
   for (const i in strapi.config.plugins.meilisearch.collections) {
     const item = strapi.config.plugins.meilisearch.collections[i]
 
-    if(index === (item.index || item.name)){
-      console.log(item);
+    if (index === (item.index || item.name)) {
+      console.log(item)
       const count = await numberOfRowsInCollection({ collection: item.name })
       const BATCH_SIZE = 1000
       const updateIds = []
@@ -172,7 +181,10 @@ async function batchAddCollection(ctx) {
           collection: item.name,
         })
 
-        const { updateId } = await indexDocuments({ collection: item.index || item.name, documents: rows.map(row => ({...row, id: item.name + row.id })) })
+        const { updateId } = await indexDocuments({
+          collection: item.index || item.name,
+          documents: rows.map(row => ({ ...row, id: item.name + row.id })),
+        })
         if (updateId) updateIds.push(updateId)
       }
     }
@@ -181,7 +193,9 @@ async function batchAddCollection(ctx) {
 
 async function addCollection(ctx) {
   let { collection } = ctx.params
-  collection = strapi.config.plugins.meilisearch.collections.find(item => item.name === collection);
+  collection = strapi.config.plugins.meilisearch.collections.find(
+    item => item.name === collection
+  )
 
   const credentials = await getCredentials()
   // Create collection in MeiliSearch
@@ -212,16 +226,25 @@ async function getCollections() {
   const indexes = await getIndexes()
   const hookedCollections = await getHookedCollections()
   const collectionTypes = getCollectionTypes()
-  const configuredCollections = strapi.config.plugins.meilisearch.collections.filter(({name, index}) => !(!name || !collectionTypes.includes(name) || (typeof index === 'string' && !index.length)));
+  const configuredCollections = strapi.config.plugins.meilisearch.collections.filter(
+    ({ name, index }) =>
+      !(
+        !name ||
+        !collectionTypes.includes(name) ||
+        (typeof index === 'string' && !index.length)
+      )
+  )
 
   const collections = configuredCollections.map(async collection => {
     const existInMeilisearch = !!indexes.find(
       index => index.name === (collection.index || collection.name)
     )
     const { numberOfDocuments = 0, isIndexing = false } = existInMeilisearch
-      ? await getStats({ collection: (collection.index || collection.name) })
+      ? await getStats({ collection: collection.index || collection.name })
       : {}
-    const numberOfRows = await numberOfRowsInCollection({ collection: collection.name })
+    const numberOfRows = await numberOfRowsInCollection({
+      collection: collection.name,
+    })
     return {
       name: collection.name,
       indexed: existInMeilisearch,

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -39,14 +39,20 @@ async function getHookedCollections() {
 }
 
 async function getCredentials() {
-  const store = await meilisearch.store()
-  const apiKey = await store.getStoreKey('meilisearch_api_key')
-  const host = await store.getStoreKey('meilisearch_host')
-  const configFileApiKey =
-    (await store.getStoreKey('meilisearch_api_key_config')) || false
-  const configFileHost =
-    (await store.getStoreKey('meilisearch_host_config')) || false
-  return { apiKey, host, configFileApiKey, configFileHost }
+  const { plugins } = strapi.config
+  if (plugins && plugins.meilisearch) {
+
+    const apiKey = plugins.meilisearch.apiKey
+    const host = plugins.meilisearch.host
+
+    if (!apiKey.length || !host.length) {
+      strapi.log.error('Meilisearch: Could not initialize: apiKey and host must be defined');
+    }
+
+    return { apiKey, host }
+  } else {
+    strapi.log.error('Meilisearch: Could not initialize: no plugin config found');
+  }
 }
 
 async function deleteAllIndexes() {

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -212,7 +212,7 @@ async function getCollections() {
   const indexes = await getIndexes()
   const hookedCollections = await getHookedCollections()
   const collectionTypes = getCollectionTypes()
-  const configuredCollections = strapi.config.plugins.meilisearch.collections.filter(({name, index}) => !(!name && !collectionTypes.includes(name) && typeof index === 'string' && !index.length))
+  const configuredCollections = strapi.config.plugins.meilisearch.collections.filter(({name, index}) => !(!name || !collectionTypes.includes(name) || (typeof index === 'string' && !index.length)));
 
   // Combine collectionTypes and configuredCollections into one
 

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -183,7 +183,11 @@ async function batchAddCollection(ctx) {
 
         const { updateId } = await indexDocuments({
           collection: item.index || item.name,
-          documents: rows.map(row => ({ ...row, id: item.name + row.id })),
+          documents: rows.map(row => ({
+            ...row,
+            id: item.name + row.id,
+            strapiCollectionName: item.name,
+          })),
         })
         if (updateId) updateIds.push(updateId)
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattiebelt/strapi-plugin-meilisearch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Synchronise and search in your Strapi collections with MeiliSearch",
   "scripts": {
     "style": "eslint --ext .js .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattiebelt/strapi-plugin-meilisearch",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Synchronise and search in your Strapi collections with MeiliSearch",
   "scripts": {
     "style": "eslint --ext .js .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "strapi-plugin-meilisearch",
-  "version": "0.3.2",
+  "name": "@mattiebelt/strapi-plugin-meilisearch",
+  "version": "0.4.0",
   "description": "Synchronise and search in your Strapi collections with MeiliSearch",
   "scripts": {
     "style": "eslint --ext .js .",
@@ -39,7 +39,7 @@
   },
   "maintainers": [
     {
-      "name": "Charlotte Vermandel <charlotte@meilisearch.com>"
+      "name": "Mattias van den Belt <mattiasvandenbelt@gmail.com>"
     }
   ],
   "engines": {
@@ -47,7 +47,7 @@
     "npm": ">=6.0.0"
   },
   "bugs": {
-    "url": "https://github.com/meilisearch/strapi-plugin-meilisearch/issues"
+    "url": "https://github.com/MattieBelt/strapi-plugin-meilisearch/issues"
   },
   "keywords": [
     "strapi",
@@ -58,9 +58,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/meilisearch/strapi-plugin-meilisearch.git"
+    "url": "https://github.com/MattieBelt/strapi-plugin-meilisearch.git"
   },
-  "homepage": "https://github.com/meilisearch/strapi-plugin-meilisearch#readme",
+  "homepage": "https://github.com/MattieBelt/strapi-plugin-meilisearch#readme",
   "devDependencies": {
     "concurrently": "^6.2.0",
     "cypress": "^7.3.0",

--- a/services/lifecycles.js
+++ b/services/lifecycles.js
@@ -7,8 +7,8 @@
 async function afterCreate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
-      indexUid: collection,
-      data: [result],
+      indexUid: collection.index || collection.name,
+      data: [{...result, id: collection.name + result.id}],
     })
   } catch (e) {
     console.error(e)
@@ -18,10 +18,10 @@ async function afterCreate(result, collection, httpClient) {
 async function afterDelete(result, collection, httpClient) {
   try {
     const documentIds = Array.isArray(result)
-      ? result.map(doc => doc.id)
-      : [result.id]
+      ? result.map(doc => collection.name + doc.id)
+      : [{...result, id: collection.name + result.id}]
     await httpClient.deleteDocuments({
-      indexUid: collection,
+      indexUid: collection.index || collection.name,
       documentIds,
     })
   } catch (e) {
@@ -32,8 +32,8 @@ async function afterDelete(result, collection, httpClient) {
 async function afterUpdate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
-      indexUid: collection,
-      data: [result],
+      indexUid: collection.index || collection.name,
+      data: [{...result, id: collection.name + result.id}],
     })
   } catch (e) {
     console.error(e)

--- a/services/lifecycles.js
+++ b/services/lifecycles.js
@@ -8,7 +8,7 @@ async function afterCreate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
       indexUid: collection.index || collection.name,
-      data: [{...result, id: collection.name + result.id}],
+      data: [{ ...result, id: collection.name + result.id }],
     })
   } catch (e) {
     console.error(e)
@@ -19,7 +19,7 @@ async function afterDelete(result, collection, httpClient) {
   try {
     const documentIds = Array.isArray(result)
       ? result.map(doc => collection.name + doc.id)
-      : [{...result, id: collection.name + result.id}]
+      : [{ ...result, id: collection.name + result.id }]
     await httpClient.deleteDocuments({
       indexUid: collection.index || collection.name,
       documentIds,
@@ -33,7 +33,7 @@ async function afterUpdate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
       indexUid: collection.index || collection.name,
-      data: [{...result, id: collection.name + result.id}],
+      data: [{ ...result, id: collection.name + result.id }],
     })
   } catch (e) {
     console.error(e)

--- a/services/lifecycles.js
+++ b/services/lifecycles.js
@@ -8,7 +8,13 @@ async function afterCreate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
       indexUid: collection.index || collection.name,
-      data: [{ ...result, id: collection.name + result.id }],
+      data: [
+        {
+          ...result,
+          id: collection.name + result.id,
+          strapiCollectionName: collection.name,
+        },
+      ],
     })
   } catch (e) {
     console.error(e)
@@ -33,7 +39,13 @@ async function afterUpdate(result, collection, httpClient) {
   try {
     await httpClient.addDocuments({
       indexUid: collection.index || collection.name,
-      data: [{ ...result, id: collection.name + result.id }],
+      data: [
+        {
+          ...result,
+          id: collection.name + result.id,
+          strapiCollectionName: collection.name,
+        },
+      ],
     })
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
**This draft PR is a way to discuss/review the changes and choices I made in the forked package [`@mattiebelt/strapi-plugin-meilisearch`](https://github.com/MattieBelt/strapi-plugin-meilisearch)**

## Use case
An user has multiple Strapi collection types in his portfolio, he has Projects, Blogs and Tools. He want to create one search bar that can search multiple indexes. As of now, this [isn't available with Meilisearch](https://roadmap.meilisearch.com/c/74-multi-index-search).

## Solution
Use one index for multiple collection types, so have a combined index (e.g. `portfolio`)

## Problem
Currently you can only enable or disable the indexing of objects per collection type with `strapi-plugin-meilisearch`.
You are not able to specify an custom index in which the objects should be created.

## Changes I made
- Only allow configuration by file (disabled UI), so this applies for:
  - Credentials
  - Collection types
- Configure an index for an collection type (e.g. `{ name: 'project', index: 'portfolio' }`)
- In the overview:
  - Separate the num. of objects in the index and the rows in the collection
  - Show the name of the index

## Why choose for file config only.
After first trying to make an index editable through the Admin panel, I ran into problems. The `getCollections` method does return based on `strapi.contentTypes, which make it not possible to save any options per collection type. So the way the collection types are handled must first be changed to allow an index to be configured through the Admin panel. Because this meant there needed to be made to much changes, I choose for file configurations with some hot glue, to just make it work. 😉 

My goal was only to make this possible for the use case from above and I also knew the code wasn't ready to be merged into this repo, that's why I choose to publish an scoped package.

## Example
```js
module.exports = () => ({
    meilisearch: {
      apiKey: "masterKey",
      host: "http://localhost:7700",
      collections: [
          { name: 'project', index: 'global' },
          { name: 'category' },
          { name: 'restaurant', index: 'global' }
        ]
    }
  })
```
![image](https://user-images.githubusercontent.com/31662805/125508612-00476e0f-8ee2-4bca-a9ce-96c326739b48.png)

## Related Issues
- #193 