### PR TITLE
Feature: allow specifying custom index name and mapping function for each model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,36 @@ To activate them, you will have to reload the server. If you are in develop mode
 <img src="./assets/no_reload_needed.png" alt="Indexed collections are hooked" width="600"/>
 </p>
 
+### Customizing search indexing
+
+1. By default, this plugin will create a search index with name same as that of model's name. This behavior can be changed by defining a property `searchIndexName` in your model.js file. For eg:
+2. By default, this plugin will send all the data present in the current model instance to MeiliSearch instance for indexing. This behavior can be changed by defining a static function called `toSearchIndex( modelInstance )` which should return the data which will be sent to MeiliSearch for indexing.
+
+For eg:
+api/mymodelname/models/mymodelname.js
+```javascript
+
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {
+  toSearchIndex(item) {
+    return {
+      id: item.id,
+      content: extractTextFromHtml(item.content), // Only index pure text content instead of indexing HTML content
+      $content_type: 'mymodelname'   // Consider that multiple entities are using same search index. So, Let's specify our model name here, so that we can identify it from the search result
+    };
+  },
+  searchIndexName: 'searchindex',
+};
+
+
+```
+
 ### 🕵️‍♀️ Start Searching <!-- omit in toc -->
 
 Once you have a collection containing documents indexed in MeiliSearch, you can [start searching](https://docs.meilisearch.com/learn/getting_started/quick_start.html#search).

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -10,6 +10,8 @@
  * See more details here: https://strapi.io/documentation/developer-docs/latest/concepts/configurations.html#bootstrap
  */
 
+const { cleanData, getIndexName } = require('../../lib/utils.js');
+
 const meilisearch = {
   http: client => strapi.plugins.meilisearch.services.http(client),
   client: credentials =>
@@ -87,7 +89,7 @@ async function initHooks(store) {
 
       // get list of Indexes In MeilISearch that are Collections in Strapi
       const indexedCollections = Object.keys(models).filter(model =>
-        indexes.includes(model)
+        indexes.includes(getIndexName(model))
       )
       addLifecycles({
         collections: indexedCollections,

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -6,6 +6,8 @@
  * @description: A set of functions called "actions" of the `meilisearch` plugin.
  */
 
+const { cleanData, getIndexName } = require('../lib/utils.js');
+
 const meilisearch = {
   http: client => strapi.plugins.meilisearch.services.http(client),
   client: credentials =>
@@ -191,7 +193,7 @@ async function getCollections() {
 
   const collections = collectionTypes.map(async collection => {
     const existInMeilisearch = !!indexes.find(
-      index => index.name === collection
+      index => index.name === getIndexName(collection)
     )
     const { numberOfDocuments = 0, isIndexing = false } = existInMeilisearch
       ? await getStats({ collection })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,46 @@
+/*
+ * Om Bhrahmarppanam
+ * lib/utils.js
+ * Created: Mon Sep 13 2021 04:51:07 GMT+0530 (GMT+05:30)
+ * Copyright 2021 Harish Karumuthil<harish2704@gmail.com>
+ */
+'use strict';
+
+/**
+ * @brief: Map model name into the actual index name in meilisearch instance. it
+ * uses `searchIndexName` property from model defnition
+ *
+ * @param indexUid - this will be equal to model's name
+ *
+ * @return {String} - Actual index name
+ */
+function getIndexName(indexUid) {
+  const model = strapi.models[indexUid];
+  return model.searchIndexName || indexUid;
+}
+
+/**
+ * @brief Convert a mode instance into data structure used for indexing.
+ *
+ * @param indexUid - This is will equal to model's name
+ * @param data {Array|Object} - The data to convert. Conversion will use
+ * `toSearchIndex` static method defined in the model defnition
+ *
+ * @return {Array|Object} - converted or mapped data
+ */
+function cleanData(indexUid, data) {
+  const model = strapi.models[indexUid];
+  const mapFunction = model.toSearchIndex;
+  if (!(mapFunction instanceof Function)) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return data.map(mapFunction);
+  }
+  return mapFunction(data);
+}
+
+module.exports = {
+  getIndexName,
+  cleanData,
+};

--- a/services/http.js
+++ b/services/http.js
@@ -6,6 +6,8 @@
  * @description: A set of functions similar to controller's actions to avoid code duplication.
  */
 
+const { cleanData, getIndexName } = require('../lib/utils.js');
+
 function removeDateLogs(document) {
   const {
     updated_at: omitUpdatedAt,
@@ -18,16 +20,21 @@ function removeDateLogs(document) {
   return noDateLogDocument
 }
 
+
 async function addDocuments({ indexUid, data }) {
+  data = cleanData(indexUid, data);
+  indexUid = getIndexName(indexUid);
   const noDateLogDocuments = data.map(document => removeDateLogs(document))
   return this.client.index(indexUid).addDocuments(noDateLogDocuments)
 }
 
 async function deleteDocuments({ indexUid, documentIds }) {
+  indexUid = getIndexName(indexUid);
   return this.client.index(indexUid).deleteDocuments(documentIds)
 }
 
 async function deleteAllDocuments({ indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client.index(indexUid).deleteAllDocuments()
 }
 
@@ -36,21 +43,24 @@ async function getIndexes() {
 }
 
 async function createIndex({ indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client.getOrCreateIndex(indexUid)
 }
 
 async function getRawIndex({ indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client.index(indexUid).getRawInfo()
 }
 
 async function waitForPendingUpdates({ indexUid, updateNbr }) {
+  indexUid = getIndexName(indexUid);
   const updates = (await this.client.index(indexUid).getAllUpdateStatus())
     .filter(update => update.status === 'enqueued')
     .slice(0, updateNbr)
   let documentsAdded = 0
   for (const update of updates) {
     const { updateId } = update
-    const task = await waitForPendingUpdate.call(this, { updateId, indexUid })
+    const task = await this.client.index(indexUid).waitForPendingUpdate(updateId, { intervalMs: 500 })
     const {
       type: { number },
     } = task
@@ -60,24 +70,27 @@ async function waitForPendingUpdates({ indexUid, updateNbr }) {
 }
 
 async function waitForPendingUpdate({ updateId, indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client
     .index(indexUid)
     .waitForPendingUpdate(updateId, { intervalMs: 500 })
 }
 
 async function deleteIndex({ indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client.deleteIndex(indexUid)
 }
 
 async function deleteIndexes() {
   const indexes = await getIndexes()
   const deletePromise = indexes.map(index =>
-    deleteIndex({ indexUid: index.uid })
+    this.client.deleteIndex(index.uid)
   )
   return Promise.all(deletePromise)
 }
 
 async function getStats({ indexUid }) {
+  indexUid = getIndexName(indexUid);
   return this.client.index(indexUid).getStats()
 }
 


### PR DESCRIPTION
Since MeiliSearch doesn't allow multi-index searching,  some time, we may need to store multiple entities in single search index. 

Also, in most cases,  we may not need to  index all the fields of a model instance. 

This PR address the above two issues by adding 
1. an optional `searchIndexName` field in model definition
2. an optional mapping function ( called `toSearchIndex` ) which will transform the data before it sent for indexing  