### PR TITLE
Support for custom index name

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,16 @@ To activate them, you will have to reload the server. If you are in develop mode
 
 #### Custom Index Name
 
-By default, this plugin will create a search index with the same name as the model. This behavior can be changed by setting a `searchIndexName` property in your model.js file.
+By default, this plugin will create a search index with the same name as the model. This behavior can be changed by setting the `indexName` property in your the model file of the related collection.
 
 **Example:**
 
-In the following example, the model `restaurant` does not create a Meilisearch index named `restaurant`, the restaurants are added to a custom index named `my_restaurant`.
+In the following example, the model `restaurant` index in MeiliSearch is called `my_restaurant` instead of the default `restaurant`.
 ```js
 // api/restaurant/models/restaurant.js
 
 module.exports = {
-  searchIndexName: "my_restaurant"
+  indexName: "my_restaurant"
 }
 ```
 
@@ -278,7 +278,7 @@ module.exports = {
                           // so that we can identify it from the search result
     };
   },
-  searchIndexName: 'searchindex',
+  indexName: 'searchindex',
 
   isUsingCompositeIndex: true, // the index 'searchindex' is shared with
                                // multiple models

--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ To activate them, you will have to reload the server. If you are in develop mode
 
 #### Custom Index Name
 
-By default, this plugin will create a search index with the same name as the model. This behavior can be changed by setting the `indexName` property in your the model file of the related collection.
+By default, when indexing a collection in MeiliSearch the index in MeiliSearch has the same name as the collection. This behavior can be changed by setting the `indexName` property in the model file of the related collection.
 
 **Example:**
 
 In the following example, the model `restaurant` index in MeiliSearch is called `my_restaurant` instead of the default `restaurant`.
+
 ```js
 // api/restaurant/models/restaurant.js
 
@@ -177,6 +178,8 @@ module.exports = {
   indexName: "my_restaurant"
 }
 ```
+
+Examples can be found [this directory](./resources/custom-index-name).
 
 #### Transform sent data
 

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -60,7 +60,7 @@ function addWatchersOnCollections({
  * @param  {object} plugin - MeiliSearch Plugins services.
  * @param  {object} models - Collections models.
  */
-async function initHooks({ store, plugin, models, services }) {
+async function initHooks({ store, plugin, models, services, logger }) {
   try {
     const credentials = await store.getCredentials()
 
@@ -74,6 +74,7 @@ async function initHooks({ store, plugin, models, services }) {
       const collectionConnector = createCollectionConnector({
         models,
         services,
+        logger,
       })
       const meilisearch = await createMeiliSearchConnector({
         collectionConnector,
@@ -82,9 +83,10 @@ async function initHooks({ store, plugin, models, services }) {
 
       // Get the list of indexes in MeilISearch that are collections in Strapi.
       try {
-        const indexes = await meilisearch.getIndexUidsOfCollectionsInMeiliSearch(
-          Object.keys(models)
-        )
+        const indexes =
+          await meilisearch.getIndexUidsOfCollectionsInMeiliSearch(
+            Object.keys(models)
+          )
 
         addWatchersOnCollections({
           collections: indexes,
@@ -113,7 +115,8 @@ async function initHooks({ store, plugin, models, services }) {
  *
  */
 module.exports = async () => {
-  const { plugin, storeClient, config, models, services } = strapiService()
+  const { plugin, storeClient, config, models, services, logger } =
+    strapiService()
 
   const store = createStoreConnector({
     plugin,
@@ -124,5 +127,5 @@ module.exports = async () => {
   await store.updateStoreCredentials(config, store)
 
   // initialize hooks
-  await initHooks({ store, plugin, models, services })
+  await initHooks({ store, plugin, models, services, logger })
 }

--- a/config/functions/bootstrap.js
+++ b/config/functions/bootstrap.js
@@ -83,10 +83,9 @@ async function initHooks({ store, plugin, models, services, logger }) {
 
       // Get the list of indexes in MeilISearch that are collections in Strapi.
       try {
-        const indexes =
-          await meilisearch.getIndexUidsOfCollectionsInMeiliSearch(
-            Object.keys(models)
-          )
+        const indexes = await meilisearch.getIndexUidsOfCollectionsInMeiliSearch(
+          Object.keys(models)
+        )
 
         addWatchersOnCollections({
           collections: indexes,
@@ -115,8 +114,14 @@ async function initHooks({ store, plugin, models, services, logger }) {
  *
  */
 module.exports = async () => {
-  const { plugin, storeClient, config, models, services, logger } =
-    strapiService()
+  const {
+    plugin,
+    storeClient,
+    config,
+    models,
+    services,
+    logger,
+  } = strapiService()
 
   const store = createStoreConnector({
     plugin,

--- a/connectors/__tests__/custom-index-name.tests.js
+++ b/connectors/__tests__/custom-index-name.tests.js
@@ -1,0 +1,194 @@
+const { MeiliSearch } = require('meilisearch')
+const createMeiliSearchConnector = require('../meilisearch')
+const createStoreConnector = require('../store')
+const createCollectionConnector = require('../collection')
+
+jest.mock('meilisearch')
+
+const addDocumentsMock = jest.fn(() => 10)
+const mockIndex = jest.fn(() => ({
+  addDocuments: addDocumentsMock,
+}))
+
+MeiliSearch.mockImplementation(() => {
+  return {
+    getOrCreateIndex: () => {
+      return mockIndex
+    },
+    index: mockIndex,
+  }
+})
+
+const storeClientMock = {
+  set: jest.fn(() => 'test'),
+  get: jest.fn(() => 'test'),
+}
+
+const servicesMock = {
+  restaurant: {
+    count: jest.fn(() => {
+      return 11
+    }),
+    find: jest.fn(() => {
+      return [{ id: '1', collection: [{ name: 'one' }, { name: 'two' }] }]
+    }),
+  },
+}
+const transformEntryMock = jest.fn(function (entry) {
+  const transformedEntry = {
+    ...entry,
+    collection: entry.collection.map(cat => cat.name),
+  }
+  return transformedEntry
+})
+
+const loggerMock = {
+  warn: jest.fn(() => 'test'),
+}
+
+describe('Test custom index names', () => {
+  let storeConnector
+  beforeEach(async () => {
+    storeConnector = createStoreConnector({
+      storeClient: storeClientMock,
+    })
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  test('Test custom index name', async () => {
+    const modelMock = {
+      restaurant: {
+        meilisearch: {
+          indexName: 'my_restaurant',
+          transformEntry: transformEntryMock,
+        },
+      },
+    }
+    const collectionConnector = createCollectionConnector({
+      logger: loggerMock,
+      models: modelMock,
+      services: servicesMock,
+    })
+    const meilisearchConnector = await createMeiliSearchConnector({
+      collectionConnector,
+      storeConnector,
+    })
+    const getIndexNameSpy = jest.spyOn(collectionConnector, 'getIndexName')
+
+    await meilisearchConnector.addCollectionInMeiliSearch('restaurant')
+
+    expect(servicesMock.restaurant.count).toHaveBeenCalledTimes(1)
+
+    expect(getIndexNameSpy).toHaveBeenCalledWith('restaurant')
+    expect(getIndexNameSpy).toHaveReturnedWith('my_restaurant')
+  })
+  test('Test no custom index name', async () => {
+    const modelMock = {
+      restaurant: {
+        meilisearch: {},
+      },
+    }
+    const collectionConnector = createCollectionConnector({
+      logger: loggerMock,
+      models: modelMock,
+      services: servicesMock,
+    })
+    const meilisearchConnector = await createMeiliSearchConnector({
+      collectionConnector,
+      storeConnector,
+    })
+    const getIndexNameSpy = jest.spyOn(collectionConnector, 'getIndexName')
+
+    await meilisearchConnector.addCollectionInMeiliSearch('restaurant')
+
+    expect(servicesMock.restaurant.count).toHaveBeenCalledTimes(1)
+
+    expect(getIndexNameSpy).toHaveBeenCalledWith('restaurant')
+    expect(getIndexNameSpy).toHaveReturnedWith('restaurant')
+  })
+
+  test('Test no meilisearch setting', async () => {
+    const modelMock = {
+      restaurant: {},
+    }
+    const collectionConnector = createCollectionConnector({
+      logger: loggerMock,
+      models: modelMock,
+      services: servicesMock,
+    })
+    const meilisearchConnector = await createMeiliSearchConnector({
+      collectionConnector,
+      storeConnector,
+    })
+    const getIndexNameSpy = jest.spyOn(collectionConnector, 'getIndexName')
+
+    await meilisearchConnector.addCollectionInMeiliSearch('restaurant')
+
+    expect(servicesMock.restaurant.count).toHaveBeenCalledTimes(1)
+
+    expect(getIndexNameSpy).toHaveBeenCalledWith('restaurant')
+    expect(getIndexNameSpy).toHaveReturnedWith('restaurant')
+  })
+
+  test('Test empty custom index name', async () => {
+    const modelMock = {
+      restaurant: {
+        indexName: '', // ignored
+      },
+    }
+    const collectionConnector = createCollectionConnector({
+      logger: loggerMock,
+      models: modelMock,
+      services: servicesMock,
+    })
+    const meilisearchConnector = await createMeiliSearchConnector({
+      collectionConnector,
+      storeConnector,
+    })
+    const getIndexNameSpy = jest.spyOn(collectionConnector, 'getIndexName')
+
+    await meilisearchConnector.addCollectionInMeiliSearch('restaurant')
+
+    expect(servicesMock.restaurant.count).toHaveBeenCalledTimes(1)
+
+    expect(getIndexNameSpy).toHaveBeenCalledWith('restaurant')
+    expect(getIndexNameSpy).toHaveReturnedWith('restaurant')
+  })
+
+  test('Test wrong type custom index name', async () => {
+    const modelMock = {
+      restaurant: {
+        meilisearch: {
+          indexName: { id: 1 }, // ignored
+        },
+      },
+    }
+    const collectionConnector = createCollectionConnector({
+      logger: loggerMock,
+      models: modelMock,
+      services: servicesMock,
+    })
+    const meilisearchConnector = await createMeiliSearchConnector({
+      collectionConnector,
+      storeConnector,
+    })
+    const getIndexNameSpy = jest.spyOn(collectionConnector, 'getIndexName')
+
+    await meilisearchConnector.addCollectionInMeiliSearch('restaurant')
+
+    expect(servicesMock.restaurant.count).toHaveBeenCalledTimes(1)
+
+    expect(getIndexNameSpy).toHaveBeenCalledWith('restaurant')
+
+    // Check if warning has been raised.
+    expect(loggerMock.warn).toHaveBeenCalledTimes(1)
+
+    // Check if invalid indexName type is ignored.
+    expect(getIndexNameSpy).toHaveReturnedWith('restaurant')
+  })
+})

--- a/connectors/__tests__/entry-transformer.tests.js
+++ b/connectors/__tests__/entry-transformer.tests.js
@@ -51,6 +51,10 @@ const modelMock = {
   },
 }
 
+const loggerMock = {
+  warn: jest.fn(() => 'test'),
+}
+
 describe('Entry transformation', () => {
   let meilisearchConnector
   let storeConnector
@@ -61,6 +65,7 @@ describe('Entry transformation', () => {
       storeClient: storeClientMock,
     })
     collectionConnector = createCollectionConnector({
+      logger: loggerMock,
       models: modelMock,
       services: servicesMock,
     })

--- a/connectors/__tests__/entry-transformer.tests.js
+++ b/connectors/__tests__/entry-transformer.tests.js
@@ -45,7 +45,7 @@ const transformEntryMock = jest.fn(function (entry) {
 const modelMock = {
   restaurant: {
     meilisearch: {
-      searchIndexName: 'my_restaurant',
+      indexName: 'my_restaurant',
       transformEntry: transformEntryMock,
     },
   },

--- a/connectors/collection.js
+++ b/connectors/collection.js
@@ -15,7 +15,7 @@ module.exports = ({ services, models, logger }) => {
       const indexName = model.indexName || collection
       if (typeof indexName !== 'string') {
         logger.warn(
-          `MEILISEARCH: "indexName" setting provided in the model of the ${collection} must be a string.`
+          `[MEILISEARCH]: "indexName" setting provided in the model of the ${collection} must be a string.`
         )
         return collection
       }

--- a/connectors/collection.js
+++ b/connectors/collection.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = ({ services, models }) => {
+module.exports = ({ services, models, logger }) => {
   return {
     /**
      * @brief: Map model name into the actual index name in meilisearch instance. it
@@ -12,7 +12,14 @@ module.exports = ({ services, models }) => {
      */
     getIndexName: function (collection) {
       const model = models[collection].meilisearch || {}
-      return model.indexName || collection
+      const indexName = model.indexName || collection
+      if (typeof indexName !== 'string') {
+        logger.warn(
+          `MEILISEARCH: "indexName" setting provided in the model of the ${collection} must be a string.`
+        )
+        return collection
+      }
+      return indexName
     },
 
     /**

--- a/connectors/collection.js
+++ b/connectors/collection.js
@@ -4,7 +4,7 @@ module.exports = ({ services, models }) => {
   return {
     /**
      * @brief: Map model name into the actual index name in meilisearch instance. it
-     * uses `searchIndexName` property from model defnition
+     * uses `indexName` property from model defnition
      *
      * @param collection - Name of the Collection.
      *
@@ -12,7 +12,7 @@ module.exports = ({ services, models }) => {
      */
     getIndexName: function (collection) {
       const model = models[collection].meilisearch || {}
-      return model.searchIndexName || collection
+      return model.indexName || collection
     },
 
     /**

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -13,10 +13,11 @@ const reloader = require('./utils/reloader')
 const strapi = require('./../services/strapi')
 
 async function createConnector() {
-  const { plugin, models, services, storeClient } = strapi()
+  const { plugin, models, services, storeClient, logger } = strapi()
   const storeConnector = createStoreConnector({ plugin, storeClient })
 
   const collectionConnector = createCollectionConnector({
+    logger,
     services,
     models,
   })

--- a/resources/custom-index-name/custom-index-name.js
+++ b/resources/custom-index-name/custom-index-name.js
@@ -1,10 +1,5 @@
 'use strict'
 
-/**
- * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
- * to customize this model
- */
-
 module.exports = {
   meilisearch: {
     indexName: 'my_custom_index_name',

--- a/resources/custom-index-name/custom-index-name.js
+++ b/resources/custom-index-name/custom-index-name.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/concepts/models.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {
+  meilisearch: {
+    indexName: 'my_custom_index_name',
+  },
+}

--- a/services/strapi.js
+++ b/services/strapi.js
@@ -10,4 +10,5 @@ module.exports = () => ({
   models: strapi.models,
   pluginConfig: strapi.config.plugins,
   services: strapi.services,
+  logger: strapi.log,
 })


### PR DESCRIPTION
In the related Collection model (for example `api/restaurant/model/restaurant.js` add the `indexName` field with the custom index name you want your collection to be named in MeiliSearch. 

For example: 

```js
// api/restaurant/models/restaurant.js

module.exports = {
  indexName: "my_restaurant"
}
```