### PR TITLE
Add data.db in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,5 @@ cypress/fixtures
 
 playground/src/plugins
 
-// 
-data.ms
+# Sqlite Database from the playground
+data.db

--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,6 @@ $RECYCLE.BIN/
 ssl
 .idea
 nbproject
-public/uploads/*
-!public/uploads/.gitkeep
 
 ############################
 # Node.js
@@ -128,3 +126,6 @@ cypress/plugins
 cypress/fixtures
 
 playground/src/plugins
+
+// 
+data.ms


### PR DESCRIPTION
`data.db` is used in the playground to add documents to meilisearch.
It should not be accidentally committed to the repo as it contains everything it needs now. 