### PR TITLE
Fix bug component/relation fields not indexed

### DIFF
--- a/server/services/lifecycle/lifecycle.js
+++ b/server/services/lifecycle/lifecycle.js
@@ -17,16 +17,20 @@ module.exports = ({ strapi }) => {
       })
       await strapi.db.lifecycles.subscribe({
         models: [contentTypeUid],
-        afterCreate(event) {
+        async afterCreate(event) {
           const { result } = event
           const meilisearch = strapi
             .plugin('meilisearch')
             .service('meilisearch')
-
+          const fullEntry = await strapi.entityService.findOne(
+            contentTypeUid,
+            result.id,
+            { populate: '*' }
+          )
           meilisearch
             .addEntriesToMeilisearch({
               contentType: contentTypeUid,
-              entries: result,
+              entries: [fullEntry],
             })
             .catch(e => {
               strapi.log.error(
@@ -39,16 +43,20 @@ module.exports = ({ strapi }) => {
             `Meilisearch does not work with \`afterCreateMany\` hook as the entries are provided without their id`
           )
         },
-        afterUpdate(event) {
+        async afterUpdate(event) {
           const { result } = event
           const meilisearch = strapi
             .plugin('meilisearch')
             .service('meilisearch')
-
+          const fullEntry = await strapi.entityService.findOne(
+            contentTypeUid,
+            result.id,
+            { populate: '*' }
+          )
           meilisearch
             .updateEntriesInMeilisearch({
               contentType: contentTypeUid,
-              entries: [result],
+              entries: [fullEntry],
             })
             .catch(e => {
               strapi.log.error(


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #376

## Explanation
Since the lifecycle `result` in the `event` object is not fully populated in some cases such as from REST API call with no `population` param. So the component/relation fields will be lost when sending it to meilisearch.

## Solution
Manual populate it using `{ populate: '*' }` before sending data to meilisearch.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
