### PR TITLE
Change getContentTypeEntries to getEntries and create getEntry  methods name

### DIFF
--- a/server/__tests__/content-types.test.js
+++ b/server/__tests__/content-types.test.js
@@ -103,7 +103,7 @@ describe('Tests content types', () => {
       strapi: fakeStrapi,
     })
 
-    const count = await contentTypeServices.getContentTypeEntries({
+    const count = await contentTypeServices.getEntries({
       contentType: 'api::restaurant.restaurant',
     })
 
@@ -115,7 +115,7 @@ describe('Tests content types', () => {
       strapi: fakeStrapi,
     })
 
-    const count = await contentTypeServices.getContentTypeEntries({
+    const count = await contentTypeServices.getEntries({
       contentType: 'api::test.test',
     })
 

--- a/server/__tests__/content-types.test.js
+++ b/server/__tests__/content-types.test.js
@@ -98,7 +98,7 @@ describe('Tests content types', () => {
     expect(count).toEqual(2)
   })
 
-  test('Test fetching entries of content type', async () => {
+  test('Test fetching entries of a content type with default parameters', async () => {
     const contentTypeServices = createContentTypeService({
       strapi: fakeStrapi,
     })
@@ -107,6 +107,51 @@ describe('Tests content types', () => {
       contentType: 'api::restaurant.restaurant',
     })
 
+    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledWith(
+      'api::restaurant.restaurant',
+      {
+        fields: '*',
+        start: 0,
+        limit: 500,
+        filters: {},
+        sort: {},
+        populate: '*',
+        publicationState: 'live',
+      }
+    )
+    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(1)
+    expect(count).toEqual([{ id: 1 }])
+  })
+
+  test('Test fetching entries of a content type with custom parameters', async () => {
+    const contentTypeServices = createContentTypeService({
+      strapi: fakeStrapi,
+    })
+
+    const count = await contentTypeServices.getEntries({
+      contentType: 'api::restaurant.restaurant',
+      fields: 'title',
+      start: 1,
+      limit: 2,
+      filters: { where: { title: 'hello' } },
+      sort: 'id',
+      populate: {},
+      publicationState: 'preview',
+    })
+
+    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledWith(
+      'api::restaurant.restaurant',
+      {
+        fields: 'title',
+        start: 1,
+        limit: 2,
+        filters: { where: { title: 'hello' } },
+        sort: 'id',
+        populate: {},
+        publicationState: 'preview',
+      }
+    )
+    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(1)
     expect(count).toEqual([{ id: 1 }])
   })
 
@@ -115,11 +160,75 @@ describe('Tests content types', () => {
       strapi: fakeStrapi,
     })
 
-    const count = await contentTypeServices.getEntries({
+    const entry = await contentTypeServices.getEntries({
       contentType: 'api::test.test',
     })
 
-    expect(count).toEqual([])
+    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(0)
+    expect(entry).toEqual([])
+  })
+
+  test('Test fetching an entry of a content type with default parameters', async () => {
+    const contentTypeServices = createContentTypeService({
+      strapi: fakeStrapi,
+    })
+
+    const entry = await contentTypeServices.getEntry({
+      contentType: 'api::restaurant.restaurant',
+      id: 200,
+    })
+
+    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledWith(
+      'api::restaurant.restaurant',
+      200,
+      {
+        fields: '*',
+        populate: '*',
+      }
+    )
+    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(1)
+    expect(entry).toEqual([{ id: 1 }])
+  })
+
+  test('Test fetching an entry of a content type with custom parameters', async () => {
+    const contentTypeServices = createContentTypeService({
+      strapi: fakeStrapi,
+    })
+
+    const entry = await contentTypeServices.getEntry({
+      contentType: 'api::restaurant.restaurant',
+      id: 200,
+      fields: ['title'],
+      populate: {
+        subClass: true,
+      },
+    })
+
+    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledWith(
+      'api::restaurant.restaurant',
+      200,
+      {
+        fields: ['title'],
+        populate: {
+          subClass: true,
+        },
+      }
+    )
+    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(1)
+    expect(entry).toEqual([{ id: 1 }])
+  })
+
+  test('Test fetching an entry on a non existing content type', async () => {
+    const contentTypeServices = createContentTypeService({
+      strapi: fakeStrapi,
+    })
+
+    const count = await contentTypeServices.getEntry({
+      contentType: 'api::test.test',
+    })
+
+    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(0)
+    expect(count).toEqual({})
   })
 
   test('Test operation in batches on entries', async () => {
@@ -136,8 +245,6 @@ describe('Tests content types', () => {
           contentType,
         })),
     })
-
-    console.log(entries)
 
     expect(entries[0].id).toEqual(2)
     expect(entries[0].contentType).toEqual(contentType)

--- a/server/__tests__/utils/fakes.js
+++ b/server/__tests__/utils/fakes.js
@@ -55,8 +55,13 @@ function createFakeStrapi({
     return [{ id: 1 }]
   })
 
+  const fakeFindOne = jest.fn(() => {
+    return [{ id: 1 }]
+  })
+
   const fakeEntityService = {
     findMany: fakeFindMany,
+    findOne: fakeFindOne,
   }
 
   const fakeStrapi = {

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -121,8 +121,37 @@ module.exports = ({ strapi }) => ({
   },
 
   /**
+   * Find an entry of a given content type.
+   * More information: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findone
+   *
+   * @param  {object} options
+   * @param  {string} [options.id] - Id of the entry.
+   * @param  {string | string[]} [options.fields] - Fields present in the returned entry.
+   * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
+   * @param  {string} [options.contentType] - Content type.
+   *
+   * @returns  {Promise<object>} - Entries.
+   */
+  async getEntry({ contentType, id, fields = '*', populate = '*' }) {
+    const contentTypeUid = this.getContentTypeUid({ contentType })
+    if (contentTypeUid === undefined) return {}
+
+    const entry = await strapi.entityService.findOne(contentTypeUid, id, {
+      fields,
+      populate,
+    })
+
+    if (entry == null) {
+      strapi.log.error(`Could not find entry with id ${id} in ${contentType}`)
+    }
+
+    return entry
+  },
+
+  /**
    * Returns a batch of entries of a given content type.
    * More information: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findmany
+   *
    * @param  {object} options
    * @param  {string | string[]} [options.fields] - Fields present in the returned entry.
    * @param  {number} [options.start] - Pagination start.
@@ -135,7 +164,7 @@ module.exports = ({ strapi }) => ({
    *
    * @returns  {Promise<object[]>} - Entries.
    */
-  async getContentTypeEntries({
+  async getEntries({
     contentType,
     fields = '*',
     start = 0,
@@ -182,7 +211,7 @@ module.exports = ({ strapi }) => ({
     const cbResponse = []
     for (let index = 0; index <= entries_count; index += BATCH_SIZE) {
       const entries =
-        (await this.getContentTypeEntries({
+        (await this.getEntries({
           start: index,
           limit: BATCH_SIZE,
           contentType,

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -125,7 +125,7 @@ module.exports = ({ strapi }) => ({
    * More information: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findone
    *
    * @param  {object} options
-   * @param  {string} [options.id] - Id of the entry.
+   * @param  {string | number} [options.id] - Id of the entry.
    * @param  {string | string[]} [options.fields] - Fields present in the returned entry.
    * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
    * @param  {string} [options.contentType] - Content type.
@@ -172,7 +172,7 @@ module.exports = ({ strapi }) => ({
     filters = {},
     sort = {},
     populate = '*',
-    publicationState,
+    publicationState = 'live',
   }) {
     const contentTypeUid = this.getContentTypeUid({ contentType })
     if (contentTypeUid === undefined) return []
@@ -184,7 +184,7 @@ module.exports = ({ strapi }) => ({
       filters,
       sort,
       populate,
-      publicationState: publicationState || 'live',
+      publicationState: publicationState,
     })
     // Safe guard in case the content-type is a single type.
     // In which case it is wrapped in an array for consistency.

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -145,7 +145,7 @@ module.exports = ({ strapi }) => ({
       strapi.log.error(`Could not find entry with id ${id} in ${contentType}`)
     }
 
-    return entry
+    return entry || {}
   },
 
   /**

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -42,7 +42,7 @@ module.exports = ({ strapi }) => {
      * @param {Array<Object>} options.entries  - The data to convert. Conversion will use
      * the static method `toSearchIndex` defined in the model definition
      *
-     * @return {Array<Object>} - Converted or mapped data
+     * @return {Promise<Array<Object>>} - Converted or mapped data
      */
     transformEntries: async function ({ contentType, entries = [] }) {
       const collection = contentTypeService.getCollectionName({ contentType })


### PR DESCRIPTION
Since these method are located in the `content-type` service it is redundant to give context in the method's name. 
This PR updates the naming for ease of read