### PR TITLE
Add populateEntryRule in plugin's settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ module.exports = {
 
 #### 👥 Populate entry rule
 
-Content-types in Strapi may have relationships with other content-types. To ensure that these links are fetched and added to an entry correctly from your Strapi database, the correct populate rule must be provided ([see documentation](https://docs-next.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html#basic-populating)).
+Content-types in Strapi may have relationships with other content-types (ex: `restaurant` can have a many-to-many relation with `category`). To ensure that these links are fetched and added to an entry correctly from your Strapi database, the correct populate rule must be provided ([see documentation](https://docs-next.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html#basic-populating)).
 
 To communicate the populate rule, use the `populateEntryRule` setting on the according content-type in the plugin's settings.
 
@@ -374,7 +374,7 @@ module.exports = {
 }
 ```
 
-by provinding this, the following is indexed in Meilisearch:
+by providing this, the following is indexed in Meilisearch:
 
 ```json
   {

--- a/README.md
+++ b/README.md
@@ -350,11 +350,11 @@ module.exports = {
 
 [See resources](./resources/meilisearch-settings) for more settings examples.
 
-#### 👥 Populate
+#### 👥 Populate entry rule
 
 Content-types in Strapi may have relationships with other content-types. To ensure that these links are fetched and added to an entry correctly from your Strapi database, the correct populate rule must be provided ([see documentation](https://docs-next.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html#basic-populating)).
 
-To communicate the populate rule, use the `populate` setting on the according content-type in the plugin's settings.
+To communicate the populate rule, use the `populateEntryRule` setting on the according content-type in the plugin's settings.
 
 **For example**
 
@@ -367,7 +367,7 @@ module.exports = {
   meilisearch: {
     config: {
       restaurant: {
-        populate: ['repeatableComponent.categories', 'categories'],
+        populateEntryRule: ['repeatableComponent.categories', 'categories'],
       }
     }
   },

--- a/README.md
+++ b/README.md
@@ -350,6 +350,60 @@ module.exports = {
 
 [See resources](./resources/meilisearch-settings) for more settings examples.
 
+#### 👥 Populate
+
+Content-types in Strapi may have relationships with other content-types. To ensure that these links are fetched and added to an entry correctly from your Strapi database, the correct populate rule must be provided ([see documentation](https://docs-next.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html#basic-populating)).
+
+To communicate the populate rule, use the `populate` setting on the according content-type in the plugin's settings.
+
+**For example**
+
+Imagine my `restaurant` content-type has a relation with a repeatable-component `repeatableComponent` that itself has a relationship with the content-type `categories`.
+
+The following population will ensure that a `restaurant` entry contains even the most nested.
+
+```js
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        populate: ['repeatableComponent.categories', 'categories'],
+      }
+    }
+  },
+}
+```
+
+by provinding this, the following is indexed in Meilisearch:
+
+```json
+  {
+    "id": "restaurant-1",
+    "title": "The slimmy snail",
+    // ... other restaurant fields
+    "repeatableComponent": [
+      {
+        "id": 1,
+        "title": "my repeatable component 1"
+        "categories": [
+          {
+            "id": 3,
+            "name": "Asian",
+            // ... other category fields
+          },
+          {
+            "id": 2,
+            "name": "Healthy",
+            // ... other category fields
+          }
+        ],
+
+      }
+    ],
+
+  }
+```
+
 ### 🕵️‍♀️ Start Searching <!-- omit in toc -->
 
 Once you have a content-type indexed in Meilisearch, you can [start searching](https://docs.meilisearch.com/learn/getting_started/quick_start.html#search).

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -212,46 +212,46 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
-  test('Test populate with wrong type', async () => {
+  test('Test populateEntryRule with wrong type', async () => {
     validateConfiguration({
       restaurant: {
-        populate: 0,
+        populateEntryRule: 0,
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populate" param of "restaurant" should be an object/array/string'
+      'the "populateEntryRule" param of "restaurant" should be an object/array/string'
     )
   })
 
-  test('Test populate with function', async () => {
+  test('Test populateEntryRule with function', async () => {
     validateConfiguration({
       restaurant: {
-        populate: () => {},
+        populateEntryRule: () => {},
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populate" param of "restaurant" should be an object/array/string'
+      'the "populateEntryRule" param of "restaurant" should be an object/array/string'
     )
   })
 
-  test('Test populate with empty object', async () => {
+  test('Test populateEntryRule with empty object', async () => {
     validateConfiguration({
       restaurant: {
-        populate: {},
+        populateEntryRule: {},
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
-  test('Test populate with undefined', async () => {
+  test('Test populateEntryRule with undefined', async () => {
     validateConfiguration({
       restaurant: {
-        populate: undefined,
+        populateEntryRule: undefined,
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -195,17 +195,63 @@ describe('Test plugin configuration', () => {
   test('Test settings with function', async () => {
     validateConfiguration({
       restaurant: {
-        settings: {},
+        settings: () => {},
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
   })
 
   test('Test settings with undefined', async () => {
     validateConfiguration({
       restaurant: {
         settings: undefined,
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('Test populate with wrong type', async () => {
+    validateConfiguration({
+      restaurant: {
+        populate: 0,
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'the "populate" param of "restaurant" should be an object/array/string'
+    )
+  })
+
+  test('Test populate with function', async () => {
+    validateConfiguration({
+      restaurant: {
+        populate: () => {},
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'the "populate" param of "restaurant" should be an object/array/string'
+    )
+  })
+
+  test('Test populate with empty object', async () => {
+    validateConfiguration({
+      restaurant: {
+        populate: {},
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('Test populate with undefined', async () => {
+    validateConfiguration({
+      restaurant: {
+        populate: undefined,
       },
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)

--- a/server/__tests__/utils/fakes.js
+++ b/server/__tests__/utils/fakes.js
@@ -55,8 +55,13 @@ function createFakeStrapi({
     return [{ id: 1 }]
   })
 
+  const fakeFindOne = jest.fn(() => {
+    return [{ id: 1 }]
+  })
+
   const fakeEntityService = {
     findMany: fakeFindMany,
+    findOne: fakeFindOne,
   }
 
   const fakeStrapi = {

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -47,6 +47,7 @@ function validateCollectionConfiguration({ configuration, collection }) {
     'transformEntry',
     'settings',
     'filterEntry',
+    'populate',
   ]
 
   if (configuration === undefined) {
@@ -96,6 +97,18 @@ function validateCollectionConfiguration({ configuration, collection }) {
       `the "settings" param of "${collection}" should be an object`
     )
     delete configuration.settings
+  }
+
+  if (
+    configuration.populate !== undefined &&
+    !isObject(configuration.populate) &&
+    !Array.isArray(configuration.populate) &&
+    typeof configuration.populate !== 'string'
+  ) {
+    strapi.log.error(
+      `the "populate" param of "${collection}" should be an object/array/string`
+    )
+    delete configuration.populate
   }
 
   Object.keys(configuration).forEach(attribute => {

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -47,7 +47,7 @@ function validateCollectionConfiguration({ configuration, collection }) {
     'transformEntry',
     'settings',
     'filterEntry',
-    'populate',
+    'populateEntryRule',
   ]
 
   if (configuration === undefined) {
@@ -100,15 +100,15 @@ function validateCollectionConfiguration({ configuration, collection }) {
   }
 
   if (
-    configuration.populate !== undefined &&
-    !isObject(configuration.populate) &&
-    !Array.isArray(configuration.populate) &&
-    typeof configuration.populate !== 'string'
+    configuration.populateEntryRule !== undefined &&
+    !isObject(configuration.populateEntryRule) &&
+    !Array.isArray(configuration.populateEntryRule) &&
+    typeof configuration.populateEntryRule !== 'string'
   ) {
     strapi.log.error(
-      `the "populate" param of "${collection}" should be an object/array/string`
+      `the "populateEntryRule" param of "${collection}" should be an object/array/string`
     )
-    delete configuration.populate
+    delete configuration.populateEntryRule
   }
 
   Object.keys(configuration).forEach(attribute => {

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -197,11 +197,16 @@ module.exports = ({ strapi }) => ({
    *
    * @param  {object} options
    * @param  {string} options.contentType - Name of the content type.
+   * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
    * @param  {function} options.callback - Function applied on each entry of the contentType.
    *
    * @returns {Promise<any[]>} - List of all the returned elements from the callback.
    */
-  actionInBatches: async function ({ contentType, callback = () => {} }) {
+  actionInBatches: async function ({
+    contentType,
+    callback = () => {},
+    populate = '*',
+  }) {
     const BATCH_SIZE = 500
 
     // Need total number of entries in contentType
@@ -215,6 +220,7 @@ module.exports = ({ strapi }) => ({
           start: index,
           limit: BATCH_SIZE,
           contentType,
+          populate,
         })) || []
 
       const info = await callback({ entries, contentType })

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -145,7 +145,7 @@ module.exports = ({ strapi }) => ({
       strapi.log.error(`Could not find entry with id ${id} in ${contentType}`)
     }
 
-    return entry
+    return entry || {}
   },
 
   /**

--- a/server/services/lifecycle/lifecycle.js
+++ b/server/services/lifecycle/lifecycle.js
@@ -42,7 +42,7 @@ module.exports = ({ strapi }) => {
               )
             })
         },
-        afterCreateMany() {
+        async afterCreateMany() {
           strapi.log.error(
             `Meilisearch does not work with \`afterCreateMany\` hook as the entries are provided without their id`
           )
@@ -72,12 +72,12 @@ module.exports = ({ strapi }) => {
               )
             })
         },
-        afterUpdateMany() {
+        async afterUpdateMany() {
           strapi.log.error(
             `Meilisearch could not find an example on how to access the \`afterUpdateMany\` hook. Please consider making an issue to explain your use case`
           )
         },
-        afterDelete(event) {
+        async afterDelete(event) {
           const { result, params } = event
           const meilisearch = strapi
             .plugin('meilisearch')
@@ -106,7 +106,7 @@ module.exports = ({ strapi }) => {
               )
             })
         },
-        afterDeleteMany() {
+        async afterDeleteMany() {
           strapi.log.error(
             `Meilisearch could not find an example on how to access the \`afterDeleteMany\` hook. Please consider making an issue to explain your use case`
           )

--- a/server/services/lifecycle/lifecycle.js
+++ b/server/services/lifecycle/lifecycle.js
@@ -25,16 +25,16 @@ module.exports = ({ strapi }) => {
 
           // Fetch complete entry instead of using result that is possibly
           // partial.
-          const fullEntry = await strapi.entityService.findOne(
-            contentTypeUid,
-            result.id,
-            { populate: '*' }
-          )
+          const entry = await contentTypeService.getEntry({
+            contentType: contentTypeUid,
+            id: result.id,
+            populate: meilisearch.populateRule({ contentType }),
+          })
 
           meilisearch
             .addEntriesToMeilisearch({
               contentType: contentTypeUid,
-              entries: [fullEntry],
+              entries: [entry],
             })
             .catch(e => {
               strapi.log.error(
@@ -55,16 +55,16 @@ module.exports = ({ strapi }) => {
 
           // Fetch complete entry instead of using result that is possibly
           // partial.
-          const fullEntry = await strapi.entityService.findOne(
-            contentTypeUid,
-            result.id,
-            { populate: '*' }
-          )
+          const entry = await contentTypeService.getEntry({
+            contentType: contentTypeUid,
+            id: result.id,
+            populate: meilisearch.populateRule({ contentType }),
+          })
 
           meilisearch
             .updateEntriesInMeilisearch({
               contentType: contentTypeUid,
-              entries: [fullEntry],
+              entries: [entry],
             })
             .catch(e => {
               strapi.log.error(

--- a/server/services/lifecycle/lifecycle.js
+++ b/server/services/lifecycle/lifecycle.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
           const entry = await contentTypeService.getEntry({
             contentType: contentTypeUid,
             id: result.id,
-            populate: meilisearch.populateRule({ contentType }),
+            populate: meilisearch.populateEntryRule({ contentType }),
           })
 
           meilisearch
@@ -58,7 +58,7 @@ module.exports = ({ strapi }) => {
           const entry = await contentTypeService.getEntry({
             contentType: contentTypeUid,
             id: result.id,
-            populate: meilisearch.populateRule({ contentType }),
+            populate: meilisearch.populateEntryRule({ contentType }),
           })
 
           meilisearch

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -36,14 +36,14 @@ module.exports = ({ strapi }) => {
     },
 
     /**
-     * Get the populate rules to apply when fetching entries in the Strapi database.
+     * Get the populate rule of a content-type that is applied when fetching entries in the Strapi database.
      *
      * @param {object} options
      * @param {string} options.contentType - ContentType name.
      *
      * @return {String} - Populate rule.
      */
-    populateRule: function ({ contentType }) {
+    populateEntryRule: function ({ contentType }) {
       const collection = contentTypeService.getCollectionName({ contentType })
       const contentTypeConfig = meilisearchConfig[collection] || {}
 

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -23,7 +23,8 @@ module.exports = ({ strapi }) => {
     /**
      * Get the name of the index from Meilisearch in which the contentType content is added.
      *
-     * @param contentType - Name of the contentType.
+     * @param {object} options
+     * @param {string} options.contentType - ContentType name.
      *
      * @return {String} - Index name
      */
@@ -32,6 +33,21 @@ module.exports = ({ strapi }) => {
 
       const contentTypeConfig = meilisearchConfig[collection] || {}
       return contentTypeConfig.indexName || collection
+    },
+
+    /**
+     * Get the populate rules to apply when fetching entries in the Strapi database.
+     *
+     * @param {object} options
+     * @param {string} options.contentType - ContentType name.
+     *
+     * @return {String} - Populate rule.
+     */
+    populateRule: function ({ contentType }) {
+      const collection = contentTypeService.getCollectionName({ contentType })
+      const contentTypeConfig = meilisearchConfig[collection] || {}
+
+      return contentTypeConfig.populate || '*'
     },
 
     /**
@@ -83,7 +99,7 @@ module.exports = ({ strapi }) => {
      * @param {Array<Object>} options.entries  - The data to convert. Conversion will use
      * the static method `toSearchIndex` defined in the model definition
      *
-     * @return {Array<Object>} - Converted or mapped data
+     * @return {Promise<Array<Object>>} - Converted or mapped data
      */
     filterEntries: async function ({ contentType, entries = [] }) {
       const collection = contentTypeService.getCollectionName({ contentType })

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -286,6 +286,7 @@ module.exports = ({ strapi, adapter, config }) => {
       const tasksUids = await contentTypeService.actionInBatches({
         contentType,
         callback: addDocuments,
+        populate: config.populateRule({ contentType }),
       })
 
       await store.addIndexedContentType({ contentType })
@@ -344,6 +345,7 @@ module.exports = ({ strapi, adapter, config }) => {
         await contentTypeService.actionInBatches({
           contentType,
           callback: deleteEntries,
+          populate: config.populateRule({ contentType }),
         })
       } else {
         const { apiKey, host } = await store.getCredentials()

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -286,7 +286,7 @@ module.exports = ({ strapi, adapter, config }) => {
       const tasksUids = await contentTypeService.actionInBatches({
         contentType,
         callback: addDocuments,
-        populate: config.populateRule({ contentType }),
+        populate: config.populateEntryRule({ contentType }),
       })
 
       await store.addIndexedContentType({ contentType })
@@ -345,7 +345,7 @@ module.exports = ({ strapi, adapter, config }) => {
         await contentTypeService.actionInBatches({
           contentType,
           callback: deleteEntries,
-          populate: config.populateRule({ contentType }),
+          populate: config.populateEntryRule({ contentType }),
         })
       } else {
         const { apiKey, host } = await store.getCredentials()


### PR DESCRIPTION
Fixes: https://github.com/meilisearch/strapi-plugin-meilisearch/issues/423
Fixes: https://github.com/meilisearch/strapi-plugin-meilisearch/issues/425

By default when fetching an entry from the Strapi database it will not always fetch every nested relationship. 
Imagine I have a collection that has a relationship with another collection, that itself has another relationship etc.. 
when fetching with `findOne` for example it will not go as deep. 

this PR introduces a setting that lets the user give the specific rule to provide to the fetching method to ensure that every nested relation is fetched how the user would like it. 