### PR TITLE
Improve Docker configuration in the package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,17 @@ First of all, thank you for contributing to Meilisearch! The goal of this docume
 
 ### Setup <!-- omit in toc -->
 
-We suggest using `yarn` as the lock file is in yarn and thus we ensure a working dev environment.
+You can set up your local environment natively or using `docker`, check out the [`docker-compose.yml`](/docker-compose.yml).
+
+Example of running all the checks with docker:
+```bash
+docker-compose run --rm package bash -c "yarn install && yarn test && yarn playground:build && yarn style"
+```
+
+To install dependencies:
 
 ```bash
-yarn
+yarn --dev
 ```
 
 ### Tests and Linter <!-- omit in toc -->

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  package:
+    image: node:16
+    tty: true
+    stdin_open: true
+    working_dir: /home/package
+    environment:
+      - MEILISEARCH_HOST=http://meilisearch:7700
+    depends_on:
+      - meilisearch
+    links:
+      - meilisearch
+    volumes:
+      - ./:/home/package
+
+  meilisearch:
+    image: getmeili/meilisearch:latest
+    ports:
+      - "7700"
+    environment:
+      - MEILI_MASTER_KEY=masterKey
+      - MEILI_NO_ANALYTICS=true


### PR DESCRIPTION
Add a basic Docker configuration based on this [integration-guides issue](https://github.com/meilisearch/integration-guides/issues/199). 

Currently no tests are done against Meilisearch, I'm still adding it to the docker-compose file so that it is already there when the tests are added.