### PR TITLE
Update meilisearch-js to beta version for v0.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@strapi/utils": "^4.1.9",
-    "meilisearch": "^0.25.1"
+    "meilisearch": "^0.27.0-beta.1"
   },
   "peerDependencies": {},
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,10 +3140,10 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-meilisearch@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.25.1.tgz#0dc25ffad64e6e50eb3da6c0691b0ff54f8578bf"
-  integrity sha512-20jO0pK9BhghxHSkOLbdoYn58h/Z0PNL3JQcRq7ipNIeqrxkAetCZZ6ttJC3uxcz0jVglmiFoSXu3Z/lEOLOLQ==
+meilisearch@^0.27.0-beta.1:
+  version "0.27.0-beta.1"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0-beta.1.tgz#62e64da55227f405e3f352a43e470947ac50f5ef"
+  integrity sha512-AnUnYKjpghPVC3zBXbF7QeikADfLyHl37aIcLS5xj+zqzku3ldQlOb9AbyBZ1gDhhWxrbltEgb0btmGyBv2jyQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
Update meilisearch-js version to prepare strapi-plugin-meilisearch to the next release of meilisearch