### PR TITLE
Fix breaking changes v0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ If you are using [Strapi v3](https://github.com/strapi/strapi/tree/v3.6.9), plea
 
 **Supported Meilisearch versions**:
 
-This package only guarantees the compatibility with the [version v0.27.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0).
+This package only guarantees the compatibility with the [version v0.28.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0).
 
 **Node / NPM versions**:
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@strapi/utils": "^4.1.9",
-    "meilisearch": "^0.25.1"
+    "meilisearch": "^0.27.0-beta.1"
   },
   "peerDependencies": {},
   "author": {

--- a/server/__tests__/meilisearch.test.js
+++ b/server/__tests__/meilisearch.test.js
@@ -13,7 +13,7 @@ const deleteDocuments = jest.fn(() => {
   return [{ uid: 1 }, { uid: 2 }]
 })
 const getIndexes = jest.fn(() => {
-  return [{ uid: 'my_restaurant' }, { uid: 'restaurant' }]
+  return { results: [{ uid: 'my_restaurant' }, { uid: 'restaurant' }] }
 })
 
 const getTasks = jest.fn(() => {

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -63,7 +63,7 @@ module.exports = ({ strapi, adapter, config }) => {
       try {
         const { apiKey, host } = await store.getCredentials()
         const client = Meilisearch({ apiKey, host })
-        const indexes = await client.getIndexes()
+        const { results: indexes } = await client.getIndexes()
         return indexes
       } catch (e) {
         strapi.log.error(`meilisearch: ${e.message}`)
@@ -280,7 +280,7 @@ module.exports = ({ strapi, adapter, config }) => {
         // Add documents in Meilisearch
         const task = await client.index(indexUid).addDocuments(documents)
 
-        return task.uid
+        return task.taskUid
       }
 
       const tasksUids = await contentTypeService.actionInBatches({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,10 +3140,10 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-meilisearch@^0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.25.1.tgz#0dc25ffad64e6e50eb3da6c0691b0ff54f8578bf"
-  integrity sha512-20jO0pK9BhghxHSkOLbdoYn58h/Z0PNL3JQcRq7ipNIeqrxkAetCZZ6ttJC3uxcz0jVglmiFoSXu3Z/lEOLOLQ==
+meilisearch@^0.27.0-beta.1:
+  version "0.27.0-beta.1"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.27.0-beta.1.tgz#62e64da55227f405e3f352a43e470947ac50f5ef"
+  integrity sha512-AnUnYKjpghPVC3zBXbF7QeikADfLyHl37aIcLS5xj+zqzku3ldQlOb9AbyBZ1gDhhWxrbltEgb0btmGyBv2jyQ==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
This plugin uses 

- getIndexes
- getTasks

Both these routes have their API design changed with the future [new release of meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0rc0)