### PR TITLE
Update client agent to correct format

### DIFF
--- a/server/services/meilisearch/client.js
+++ b/server/services/meilisearch/client.js
@@ -12,7 +12,5 @@ const packageJson = require('../../../package.json')
 module.exports = config =>
   new Meilisearch({
     ...config,
-    clientAgents: [
-      `Meilisearch strapi-plugin-meilisearch ${packageJson.version}`,
-    ],
+    clientAgents: [`Meilisearch Strapi ${packageJson.version}`],
   })


### PR DESCRIPTION
As per [this comment](https://github.com/meilisearch/integration-guides/issues/150#issuecomment-1043262254) the client agent should be `Meilisearch Strapi (v.X.X.X)`

