### PR TITLE
Update invalid link in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add your Strapi content-types into a Meilisearch instance. The plugin listens to
 
 ## 📖 Documentation
 
-To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://docs.meilisearch.com/learn/what_is_meilisearch/).
+To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://docs.meilisearch.com/learn/getting_started/quick_start.html).
 
 To understand Strapi and how to create an app, see [Strapi's documentation](https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html).
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fix invalid link in the README.
Under the Documentation section in the sentence: "To understand Meilisearch and how it works, see the Meilisearch's documentation". The link: https://docs.meilisearch.com/learn/what_is_meilisearch/ is unavailable.
## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
