### PR TITLE
Use strapi dev without flag to run the playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "description": "Synchronise and search in your Strapi content-types with Meilisearch",
   "scripts": {
-    "playground:dev": "yarn --cwd ./playground && yarn --cwd ./playground develop",
+    "playground:dev": "yarn --cwd ./playground && yarn --cwd ./playground dev",
     "playground:build": "yarn --cwd ./playground && yarn --cwd ./playground build",
     "style": "eslint --ext .js,.test.js .",
     "style:fix": "eslint --ext .js,.test.js . --fix",

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "description": "A Strapi application",
   "scripts": {
-    "develop": "strapi develop --watch-admin",
     "dev": "strapi develop",
     "start": "strapi start",
     "build": "strapi build",


### PR DESCRIPTION
Since this bug was introduced https://github.com/strapi/strapi/issues/13852 I removed the flag usage during dev to avoid a breaking app