### PR TITLE
Update version for the next release (v.0.7.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-meilisearch",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Synchronise and search in your Strapi content-types with Meilisearch",
   "scripts": {
     "playground:dev": "yarn --cwd ./playground && yarn --cwd ./playground dev",


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.
