### PR TITLE
Add an orderby when fetching from the database

### DIFF
--- a/server/__tests__/content-types.test.js
+++ b/server/__tests__/content-types.test.js
@@ -114,7 +114,7 @@ describe('Tests content types', () => {
         start: 0,
         limit: 500,
         filters: {},
-        sort: {},
+        sort: 'id',
         populate: '*',
         publicationState: 'live',
       }

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -157,7 +157,7 @@ module.exports = ({ strapi }) => ({
    * @param  {number} [options.start] - Pagination start.
    * @param  {number} [options.limit] - Number of entries to return.
    * @param  {object} [options.filters] - Filters to use.
-   * @param  {object} [options.sort] - Order definition.
+   * @param  {object|string} [options.sort] - Order definition.
    * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
    * @param  {object} [options.publicationState] - Publication state: live or preview.
    * @param  {string} [options.contentType] - Content type.
@@ -170,7 +170,7 @@ module.exports = ({ strapi }) => ({
     start = 0,
     limit = 500,
     filters = {},
-    sort = {},
+    sort = 'id',
     populate = '*',
     publicationState = 'live',
   }) {


### PR DESCRIPTION
When using PostgreSQL on a large database, if you paginate using offset, it may happen that psql do not follow the same rule to order the documents.

Meaning that, if I make multiple requests with different offsets, I might receive back documents that I already fetched before.

Exemple:

Running `Select * FROM x OFFSET 100` two times might return different documents.

To tackle that issue, we need to add an `order by` during the request. This ensures the database follows the same order for the documents.

