### PR TITLE
Remove unecessary build in publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,6 @@ jobs:
         run: sh .github/scripts/check-release.sh
       - name: Check tag format
         run: sh .github/scripts/check-tag-format.sh "${{ github.event.release.prerelease }}"
-      - name: Install dependencies
-        run: yarn install
-      - name: Build instant-meilisearch
-        run: yarn build
       - name: Publish with latest tag
         if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
         run: npm publish .


### PR DESCRIPTION
`Yarn install` and `yarn build` were added to this PR https://github.com/meilisearch/strapi-plugin-meilisearch/pull/475 while they shouldn't have. 

Remove them as they are breaking the CI