### PR TITLE
Refactor validation file for readability purposes

### DIFF
--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -179,6 +179,39 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
+  test('Test filterEntry with wrong type', async () => {
+    validateConfiguration({
+      restaurant: {
+        filterEntry: 0,
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'the "filterEntry" option of "restaurant" should be a function'
+    )
+  })
+
+  test('Test filterEntry with function', async () => {
+    validateConfiguration({
+      restaurant: {
+        filterEntry: () => {},
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+  })
+
+  test('Test filterEntry with undefined', async () => {
+    validateConfiguration({
+      restaurant: {
+        filterEntry: undefined,
+      },
+    })
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+  })
+
   test('Test settings with wrong type', async () => {
     validateConfiguration({
       restaurant: {

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -122,7 +122,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "indexName" param of "restaurant" should be a non-empty string'
+      'the "indexName" option of "restaurant" should be a non-empty string'
     )
   })
 
@@ -155,7 +155,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "transformEntry" param of "restaurant" should be a function'
+      'the "transformEntry" option of "restaurant" should be a function'
     )
   })
 
@@ -188,7 +188,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "settings" param of "restaurant" should be an object'
+      'the "settings" option of "restaurant" should be an object'
     )
   })
 
@@ -221,7 +221,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populateEntryRule" param of "restaurant" should be an object/array/string'
+      'the "populateEntryRule" option of "restaurant" should be an object/array/string'
     )
   })
 
@@ -234,7 +234,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populateEntryRule" param of "restaurant" should be an object/array/string'
+      'the "populateEntryRule" option of "restaurant" should be an object/array/string'
     )
   })
 
@@ -267,7 +267,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.warn).toHaveBeenCalledWith(
-      'The attribute "random" of "restaurant" is not a known parameter'
+      'The attribute "random" of "restaurant" is not a known option'
     )
   })
 })

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -58,7 +58,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      '`host` should be a non-empty string in Meilisearch configuration'
+      '`host` should be a non-empty string in Meilisearch plugin configuration'
     )
   })
 
@@ -85,7 +85,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      '`apiKey` should be a string in Meilisearch configuration'
+      '`apiKey` should be a string in Meilisearch plugin configuration'
     )
   })
 

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -1,4 +1,4 @@
-const { validateConfiguration } = require('../configuration-validation')
+const { validatePluginConfig } = require('../configuration-validation')
 
 const { createFakeStrapi } = require('./utils/fakes')
 
@@ -12,39 +12,39 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test empty configuration', async () => {
-    validateConfiguration()
+    validatePluginConfig()
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test wrong type config configuration', async () => {
-    validateConfiguration(1)
+    validatePluginConfig(1)
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'The `config` field in the Meilisearch plugin configuration must be of type object'
+      'The "config" field in the Meilisearch plugin configuration should be an object'
     )
   })
 
   test('Test wrong object configuration', async () => {
-    validateConfiguration({})
+    validatePluginConfig({})
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with not used attribute', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       hello: 0,
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'The collection "hello" should be of type object'
+      'The collection "hello" configuration should be of type object'
     )
   })
 
   test('Test configuration with empty host', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       host: undefined,
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -52,18 +52,18 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with empty string host', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       host: '',
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      '`host` should be a non-empty string in Meilisearch plugin configuration'
+      'The "host" option should be a non-empty string'
     )
   })
 
   test('Test configuration with string host', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       host: 'test',
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -71,7 +71,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with empty apiKey', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       apiKey: undefined,
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -79,18 +79,18 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with wrong time apiKey', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       apiKey: 0,
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      '`apiKey` should be a string in Meilisearch plugin configuration'
+      'The "apiKey" option should be a string'
     )
   })
 
   test('Test configuration with empty string apiKey', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       apiKey: '',
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -98,7 +98,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with string apiKey', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       apiKey: 'test',
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -106,7 +106,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with string apiKey', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       apiKey: 'test',
     })
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
@@ -114,7 +114,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test indexName with empty string', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         indexName: '',
       },
@@ -122,12 +122,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "indexName" option of "restaurant" should be a non-empty string'
+      'The "indexName" option of "restaurant" should be a non-empty string'
     )
   })
 
   test('Test indexName with non-empty string', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         indexName: 'hello',
       },
@@ -137,7 +137,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test indexName with undefined', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         indexName: undefined,
       },
@@ -147,7 +147,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test transformEntry with wrong type', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         transformEntry: 0,
       },
@@ -155,12 +155,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "transformEntry" option of "restaurant" should be a function'
+      'The "transformEntry" option of "restaurant" should be a function'
     )
   })
 
   test('Test transformEntry with function', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         transformEntry: () => {},
       },
@@ -170,7 +170,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test transformEntry with undefined', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         transformEntry: undefined,
       },
@@ -180,7 +180,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test filterEntry with wrong type', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         filterEntry: 0,
       },
@@ -188,12 +188,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "filterEntry" option of "restaurant" should be a function'
+      'The "filterEntry" option of "restaurant" should be a function'
     )
   })
 
   test('Test filterEntry with function', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         filterEntry: () => {},
       },
@@ -203,7 +203,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test filterEntry with undefined', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         filterEntry: undefined,
       },
@@ -213,7 +213,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test settings with wrong type', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         settings: 0,
       },
@@ -221,12 +221,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "settings" option of "restaurant" should be an object'
+      'The "settings" option of "restaurant" should be an object'
     )
   })
 
   test('Test settings with function', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         settings: () => {},
       },
@@ -236,7 +236,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test settings with undefined', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         settings: undefined,
       },
@@ -246,7 +246,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test populateEntryRule with wrong type', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         populateEntryRule: 0,
       },
@@ -254,12 +254,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populateEntryRule" option of "restaurant" should be an object/array/string'
+      'The "populateEntryRule" option of "restaurant" should be an object/array/string'
     )
   })
 
   test('Test populateEntryRule with function', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         populateEntryRule: () => {},
       },
@@ -267,12 +267,12 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'the "populateEntryRule" option of "restaurant" should be an object/array/string'
+      'The "populateEntryRule" option of "restaurant" should be an object/array/string'
     )
   })
 
   test('Test populateEntryRule with empty object', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         populateEntryRule: {},
       },
@@ -282,7 +282,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test populateEntryRule with undefined', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         populateEntryRule: undefined,
       },
@@ -292,7 +292,7 @@ describe('Test plugin configuration', () => {
   })
 
   test('Test configuration with random field ', async () => {
-    validateConfiguration({
+    validatePluginConfig({
       restaurant: {
         random: undefined,
       },
@@ -300,7 +300,7 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(1)
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
     expect(fakeStrapi.log.warn).toHaveBeenCalledWith(
-      'The attribute "random" of "restaurant" is not a known option'
+      'The "random" option of "restaurant" is not a known option'
     )
   })
 })

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -7,19 +7,22 @@ const { isObject } = require('./utils')
  * @param  {object} config - configurations
  */
 function validateConfiguration(config) {
+  // If no configuration, return
   if (config === undefined) {
     return
   }
 
+  // Configuration must be an object
   if (!isObject(config)) {
     strapi.log.error(
       'The `config` field in the Meilisearch plugin configuration must be of type object'
     )
     config = {}
   }
+
   const { host, apiKey, ...collections } = config
 
-  // Validate the `host` parameter
+  // Validate the `host` option
   if ((host !== undefined && typeof host !== 'string') || config.host === '') {
     strapi.log.error(
       '`host` should be a non-empty string in Meilisearch configuration'
@@ -27,13 +30,15 @@ function validateConfiguration(config) {
     delete config.host
   }
 
-  // Validate the `apikey` parameter
+  // Validate the `apikey` option
   if (apiKey !== undefined && typeof apiKey !== 'string') {
     strapi.log.error('`apiKey` should be a string in Meilisearch configuration')
     delete config.apiKey
   }
 
+  // Validate the `collections` option
   for (const collection in collections) {
+    // Validate the configuration for each collection
     config[collection] = validateCollectionConfiguration({
       configuration: collections[collection],
       collection: collection,
@@ -48,73 +53,95 @@ function validateCollectionConfiguration({ configuration, collection }) {
     'settings',
     'filterEntry',
     'populateEntryRule',
+    'dbQueryOptions',
   ]
 
+  // if the collection has no configuration, return
   if (configuration === undefined) {
     return
   }
 
+  // Validate the configuration type of the collection
   if (configuration !== undefined && !isObject(configuration)) {
     strapi.log.error(`The collection "${collection}" should be of type object`)
     return {}
   }
 
-  const { indexName } = configuration
+  const {
+    indexName,
+    transformEntry,
+    filterEntry,
+    dbQueryOptions,
+    populateEntryRule,
+    settings,
+  } = configuration
+
+  // Validate the `indexName` option
   if (
     (indexName !== undefined && typeof indexName !== 'string') ||
     indexName === ''
   ) {
     strapi.log.error(
-      `the "indexName" param of "${collection}" should be a non-empty string`
+      `the "indexName" option of "${collection}" should be a non-empty string`
     )
     delete configuration.indexName
   }
-  if (
-    configuration.transformEntry !== undefined &&
-    typeof configuration.transformEntry !== 'function'
-  ) {
+
+  // Validate the `transformEntry` option
+  if (transformEntry !== undefined && typeof transformEntry !== 'function') {
     strapi.log.error(
-      `the "transformEntry" param of "${collection}" should be a function`
+      `the "transformEntry" option of "${collection}" should be a function`
     )
     delete configuration.transformEntry
   }
 
-  if (
-    configuration.filterEntry !== undefined &&
-    typeof configuration.filterEntry !== 'function'
-  ) {
+  // Validate the `filterEntry` option
+  if (filterEntry !== undefined && typeof filterEntry !== 'function') {
     strapi.log.error(
-      `the "filterEntry" param of "${collection}" should be a function`
+      `the "filterEntry" option of "${collection}" should be a function`
     )
     delete configuration.filterEntry
   }
 
-  if (
-    configuration.settings !== undefined &&
-    !isObject(configuration.settings)
-  ) {
+  // Validate the `settings` option
+  if (settings !== undefined && !isObject(settings)) {
     strapi.log.error(
-      `the "settings" param of "${collection}" should be an object`
+      `the "settings" option of "${collection}" should be an object`
     )
     delete configuration.settings
   }
 
+  console.log(configuration.dbQueryOptions)
+
+  // Validate the `dbQueryOptions` option
   if (
-    configuration.populateEntryRule !== undefined &&
-    !isObject(configuration.populateEntryRule) &&
-    !Array.isArray(configuration.populateEntryRule) &&
-    typeof configuration.populateEntryRule !== 'string'
+    configuration.dbQueryOptions !== undefined &&
+    !isObject(configuration.dbQueryOptions)
   ) {
     strapi.log.error(
-      `the "populateEntryRule" param of "${collection}" should be an object/array/string`
+      `the "dbQueryOptions" option of "${collection}" should be an object`
+    )
+    delete configuration.dbQueryOptions
+  }
+
+  // Validate the `populateEntryRule` option
+  if (
+    populateEntryRule !== undefined &&
+    !isObject(populateEntryRule) &&
+    !Array.isArray(populateEntryRule) &&
+    typeof populateEntryRule !== 'string'
+  ) {
+    strapi.log.error(
+      `the "populateEntryRule" option of "${collection}" should be an object/array/string`
     )
     delete configuration.populateEntryRule
   }
 
+  // Ensure that there are no additional unknown keys
   Object.keys(configuration).forEach(attribute => {
     if (!validApiFields.includes(attribute)) {
       strapi.log.warn(
-        `The attribute "${attribute}" of "${collection}" is not a known parameter`
+        `The attribute "${attribute}" of "${collection}" is not a known option`
       )
       delete configuration[attribute]
     }

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -1,6 +1,6 @@
 const { isObject } = require('./utils')
 
-function CollectionConfig(collectionName, configuration) {
+function CollectionConfig({ collectionName, configuration }) {
   const log = strapi.log // has to be inside a scope
   const {
     indexName,
@@ -105,7 +105,7 @@ function CollectionConfig(collectionName, configuration) {
   }
 }
 
-function PluginConfig(configuration) {
+function PluginConfig({ configuration }) {
   const log = strapi.log // has to be inside a scope
   const { apiKey, host, ...collections } = configuration
   const options = {}
@@ -140,10 +140,10 @@ function PluginConfig(configuration) {
           )
           options[collection] = {}
         } else {
-          options[collection] = CollectionConfig(
-            collection,
-            collections[collection]
-          )
+          options[collection] = CollectionConfig({
+            collectionName: collection,
+            configuration: collections[collection],
+          })
             .validateIndexName()
             .validateFilterEntry()
             .validateTransformEntry()
@@ -166,28 +166,28 @@ function PluginConfig(configuration) {
  * Validates the plugin configuration provided in `plugins/config.js` of the users plugin configuration.
  * Modifies the value of config on place.
  *
- * @param  {object} config - The plugin configuration
+ * @param  {object} configuration - The plugin configuration
  */
-function validatePluginConfig(config) {
+function validatePluginConfig(configuration) {
   const log = strapi.log
 
   // If no configuration, return
-  if (config === undefined) {
+  if (configuration === undefined) {
     return
-  } else if (config !== undefined && !isObject(config)) {
+  } else if (configuration !== undefined && !isObject(configuration)) {
     log.error(
       'The "config" field in the Meilisearch plugin configuration should be an object'
     )
     return
   }
 
-  const options = PluginConfig(config)
+  const options = PluginConfig({ configuration })
     .validateApiKey()
     .validateHost()
     .validateCollections()
     .get()
 
-  Object.assign(config, options)
+  Object.assign(configuration, options)
 }
 
 module.exports = {

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -1,152 +1,184 @@
 const { isObject } = require('./utils')
 
+function CollectionOptions(name, configuration) {
+  const log = strapi.log // has to be inside a scope
+  const {
+    indexName,
+    transformEntry,
+    filterEntry,
+    settings,
+    populateEntryRule,
+    ...excedent
+  } = configuration
+  const options = {}
+
+  return {
+    validateConfiguration() {
+      if (configuration !== undefined && !isObject(configuration)) {
+        log.error(`The collection "${name}" should be of type object`)
+      }
+
+      return this
+    },
+    validateIndexName() {
+      if (
+        (indexName !== undefined && typeof indexName !== 'string') ||
+        indexName === ''
+      ) {
+        log.error(
+          `the "indexName" option of "${name}" should be a non-empty string`
+        )
+      } else if (indexName !== undefined) {
+        options.indexName = indexName
+      }
+
+      return this
+    },
+    validateTransformEntry() {
+      // Validate the `transformEntry` option
+      if (
+        transformEntry !== undefined &&
+        typeof transformEntry !== 'function'
+      ) {
+        log.error(
+          `the "transformEntry" option of "${name}" should be a function`
+        )
+      } else if (transformEntry !== undefined) {
+        options.transformEntry = transformEntry
+      }
+
+      return this
+    },
+    validateFilterEntry() {
+      // Validate the `filterEntry` option
+      if (filterEntry !== undefined && typeof filterEntry !== 'function') {
+        log.error(`the "filterEntry" option of "${name}" should be a function`)
+      } else if (filterEntry !== undefined) {
+        options.filterEntry = filterEntry
+      }
+
+      return this
+    },
+    validateMeilisearchSettings() {
+      // Validate the `settings` option
+      if (settings !== undefined && !isObject(settings)) {
+        log.error(`the "settings" option of "${name}" should be an object`)
+      } else if (settings !== undefined) {
+        options.settings = settings
+      }
+
+      return this
+    },
+    validatePopulateEntryRule() {
+      // Validate the `populateEntryRule` option
+      if (
+        populateEntryRule !== undefined &&
+        !isObject(populateEntryRule) &&
+        !Array.isArray(populateEntryRule) &&
+        typeof populateEntryRule !== 'string'
+      ) {
+        log.error(
+          `the "populateEntryRule" option of "${name}" should be an object/array/string`
+        )
+      } else if (populateEntryRule !== undefined) {
+        options.populateEntryRule = populateEntryRule
+      }
+
+      return this
+    },
+    validateNoInvalidKeys() {
+      Object.keys(excedent).map(key => {
+        log.warn(`The attribute "${key}" of "${name}" is not a known option`)
+      })
+
+      return this
+    },
+    get() {
+      return options
+    },
+  }
+}
+
+function PluginOptions(configuration) {
+  const log = strapi.log // has to be inside a scope
+  const { apiKey, host, ...collections } = configuration
+  const options = {}
+
+  return {
+    validateConfiguration() {
+      // Configuration must be an object
+      if (!isObject(configuration)) {
+        log.error(
+          'The `config` field in the Meilisearch plugin configuration must be of type object'
+        )
+      }
+
+      return this
+    },
+    validateApiKey() {
+      if (apiKey !== undefined && typeof apiKey !== 'string') {
+        log.error(
+          '`apiKey` should be a string in Meilisearch plugin configuration'
+        )
+      } else if (apiKey !== undefined) {
+        options.apiKey = apiKey
+      }
+      return this
+    },
+    validateHost() {
+      // Validate the `host` option
+      if ((host !== undefined && typeof host !== 'string') || host === '') {
+        log.error(
+          '`host` should be a non-empty string in Meilisearch plugin configuration'
+        )
+      } else if (host !== undefined) {
+        options.host = host
+      }
+      return this
+    },
+    validateCollectionConfigurations() {
+      for (const collection in collections) {
+        options[collection] = CollectionOptions(
+          collection,
+          collections[collection]
+        )
+          .validateConfiguration()
+          .validateIndexName()
+          .validateFilterEntry()
+          .validateTransformEntry()
+          .validateMeilisearchSettings()
+          .validatePopulateEntryRule()
+          .validateNoInvalidKeys()
+          .get()
+      }
+      return this
+    },
+    get() {
+      return options
+    },
+  }
+}
+
 /**
  * Validates the plugin configuration provided in `plugins/config.js` of the users plugin configuration.
  * Modifies the value of config on place.
  *
  * @param  {object} config - configurations
  */
-function validateConfiguration(config) {
+function validateConfiguration(configuration) {
   // If no configuration, return
-  if (config === undefined) {
-    return
-  }
-
-  // Configuration must be an object
-  if (!isObject(config)) {
-    strapi.log.error(
-      'The `config` field in the Meilisearch plugin configuration must be of type object'
-    )
-    config = {}
-  }
-
-  const { host, apiKey, ...collections } = config
-
-  // Validate the `host` option
-  if ((host !== undefined && typeof host !== 'string') || config.host === '') {
-    strapi.log.error(
-      '`host` should be a non-empty string in Meilisearch configuration'
-    )
-    delete config.host
-  }
-
-  // Validate the `apikey` option
-  if (apiKey !== undefined && typeof apiKey !== 'string') {
-    strapi.log.error('`apiKey` should be a string in Meilisearch configuration')
-    delete config.apiKey
-  }
-
-  // Validate the `collections` option
-  for (const collection in collections) {
-    // Validate the configuration for each collection
-    config[collection] = validateCollectionConfiguration({
-      configuration: collections[collection],
-      collection: collection,
-    })
-  }
-}
-
-function validateCollectionConfiguration({ configuration, collection }) {
-  const validApiFields = [
-    'indexName',
-    'transformEntry',
-    'settings',
-    'filterEntry',
-    'populateEntryRule',
-    'dbQueryOptions',
-  ]
-
-  // if the collection has no configuration, return
   if (configuration === undefined) {
     return
   }
 
-  // Validate the configuration type of the collection
-  if (configuration !== undefined && !isObject(configuration)) {
-    strapi.log.error(`The collection "${collection}" should be of type object`)
-    return {}
-  }
+  const options = PluginOptions(configuration)
+    .validateConfiguration()
+    .validateApiKey()
+    .validateHost()
+    .validateCollectionConfigurations()
+    .get()
 
-  const {
-    indexName,
-    transformEntry,
-    filterEntry,
-    dbQueryOptions,
-    populateEntryRule,
-    settings,
-  } = configuration
-
-  // Validate the `indexName` option
-  if (
-    (indexName !== undefined && typeof indexName !== 'string') ||
-    indexName === ''
-  ) {
-    strapi.log.error(
-      `the "indexName" option of "${collection}" should be a non-empty string`
-    )
-    delete configuration.indexName
-  }
-
-  // Validate the `transformEntry` option
-  if (transformEntry !== undefined && typeof transformEntry !== 'function') {
-    strapi.log.error(
-      `the "transformEntry" option of "${collection}" should be a function`
-    )
-    delete configuration.transformEntry
-  }
-
-  // Validate the `filterEntry` option
-  if (filterEntry !== undefined && typeof filterEntry !== 'function') {
-    strapi.log.error(
-      `the "filterEntry" option of "${collection}" should be a function`
-    )
-    delete configuration.filterEntry
-  }
-
-  // Validate the `settings` option
-  if (settings !== undefined && !isObject(settings)) {
-    strapi.log.error(
-      `the "settings" option of "${collection}" should be an object`
-    )
-    delete configuration.settings
-  }
-
-  console.log(configuration.dbQueryOptions)
-
-  // Validate the `dbQueryOptions` option
-  if (
-    configuration.dbQueryOptions !== undefined &&
-    !isObject(configuration.dbQueryOptions)
-  ) {
-    strapi.log.error(
-      `the "dbQueryOptions" option of "${collection}" should be an object`
-    )
-    delete configuration.dbQueryOptions
-  }
-
-  // Validate the `populateEntryRule` option
-  if (
-    populateEntryRule !== undefined &&
-    !isObject(populateEntryRule) &&
-    !Array.isArray(populateEntryRule) &&
-    typeof populateEntryRule !== 'string'
-  ) {
-    strapi.log.error(
-      `the "populateEntryRule" option of "${collection}" should be an object/array/string`
-    )
-    delete configuration.populateEntryRule
-  }
-
-  // Ensure that there are no additional unknown keys
-  Object.keys(configuration).forEach(attribute => {
-    if (!validApiFields.includes(attribute)) {
-      strapi.log.warn(
-        `The attribute "${attribute}" of "${collection}" is not a known option`
-      )
-      delete configuration[attribute]
-    }
-  })
-  return configuration
+  Object.assign(configuration, options)
 }
 
 module.exports = {

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -171,7 +171,7 @@ function PluginOptions(configuration) {
  * Validates the plugin configuration provided in `plugins/config.js` of the users plugin configuration.
  * Modifies the value of config on place.
  *
- * @param  {object} config - configurations
+ * @param  {object} configuration - configurations
  */
 function validateConfiguration(configuration) {
   // If no configuration, return

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -14,6 +14,7 @@ function CollectionOptions(name, configuration) {
 
   return {
     validateConfiguration() {
+      // Configuration is either undefined or an object
       if (configuration !== undefined && !isObject(configuration)) {
         log.error(`The collection "${name}" should be of type object`)
       }
@@ -21,6 +22,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validateIndexName() {
+      // indexName is either undefined or a none empty string
       if (
         (indexName !== undefined && typeof indexName !== 'string') ||
         indexName === ''
@@ -35,7 +37,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validateTransformEntry() {
-      // Validate the `transformEntry` option
+      // transformEntry is either undefined or a function
       if (
         transformEntry !== undefined &&
         typeof transformEntry !== 'function'
@@ -50,7 +52,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validateFilterEntry() {
-      // Validate the `filterEntry` option
+      // filterEntry is either undefined or a function
       if (filterEntry !== undefined && typeof filterEntry !== 'function') {
         log.error(`the "filterEntry" option of "${name}" should be a function`)
       } else if (filterEntry !== undefined) {
@@ -60,7 +62,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validateMeilisearchSettings() {
-      // Validate the `settings` option
+      // Settings is either undefined or an object
       if (settings !== undefined && !isObject(settings)) {
         log.error(`the "settings" option of "${name}" should be an object`)
       } else if (settings !== undefined) {
@@ -70,7 +72,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validatePopulateEntryRule() {
-      // Validate the `populateEntryRule` option
+      // PopulateEntry is either undefined or an object/array/string`
       if (
         populateEntryRule !== undefined &&
         !isObject(populateEntryRule) &&
@@ -87,6 +89,7 @@ function CollectionOptions(name, configuration) {
       return this
     },
     validateNoInvalidKeys() {
+      // Keys that should not be present in the configuration
       Object.keys(excedent).map(key => {
         log.warn(`The attribute "${key}" of "${name}" is not a known option`)
       })
@@ -115,7 +118,9 @@ function PluginOptions(configuration) {
 
       return this
     },
+
     validateApiKey() {
+      // apiKey is either undefined or a string
       if (apiKey !== undefined && typeof apiKey !== 'string') {
         log.error(
           '`apiKey` should be a string in Meilisearch plugin configuration'
@@ -125,8 +130,9 @@ function PluginOptions(configuration) {
       }
       return this
     },
+
     validateHost() {
-      // Validate the `host` option
+      // // apiKey is either undefined or a none empty string
       if ((host !== undefined && typeof host !== 'string') || host === '') {
         log.error(
           '`host` should be a non-empty string in Meilisearch plugin configuration'
@@ -136,7 +142,9 @@ function PluginOptions(configuration) {
       }
       return this
     },
+
     validateCollectionConfigurations() {
+      // Itterate over all collections to validate their configuration
       for (const collection in collections) {
         options[collection] = CollectionOptions(
           collection,

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -122,7 +122,7 @@ function PluginConfig(configuration) {
     },
 
     validateHost() {
-      // // apiKey is either undefined or a none empty string
+      // apiKey is either undefined or a none empty string
       if ((host !== undefined && typeof host !== 'string') || host === '') {
         log.error('The "host" option should be a non-empty string')
       } else if (host !== undefined) {

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -5,7 +5,7 @@ const services = require('./server/services')
 const controllers = require('./server/controllers')
 const routes = require('./server/routes')
 const policies = require('./server/policies')
-const { validateConfiguration } = require('./server/configuration-validation')
+const { validatePluginConfig } = require('./server/configuration-validation')
 
 module.exports = {
   bootstrap,
@@ -14,6 +14,6 @@ module.exports = {
   routes,
   policies,
   config: {
-    validator: validateConfiguration,
+    validator: validatePluginConfig,
   },
 }


### PR DESCRIPTION
Previously when validating the configuration that the user can provide in their `plugins.js` file, we used a hard to read if jungle.

This PR updates the validation to a builder design.

