### PR TITLE
Add entries query option in plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,8 +375,8 @@ module.exports = {
 
 ### 🔎 Entries query
 
-When indexing a content-type to Meilisearch, the plugin has to fetch the documents from your database. With `entriesQuery` it is possible to specify some options that should be apply during the fetching of the entries.
-The options that you can set are described in the [`findMany` documentation](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findmany) of Strapi. However, we do not accept any changes on the `start` parameter.
+When indexing a content type to Meilisearch, the plugin has to fetch the documents from your database. With `entriesQuery` it is possible to specify some options that should be applied during the fetching of the entries.
+The options you can set are described in the [`findMany` documentation](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findmany) of Strapi. However, we do not accept any changes on the `start` parameter.
 
 If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` can also be added in `entriesQuery`.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Settings:
 - [🪄 Transform entries](#-transform-entries)
 - [🤚 Filter entries](#-filter-entries)
 - [🏗 Add Meilisearch settings](#-add-meilisearch-settings)
-- [👥 Populate entry rule](#-populate-entry-rule)
+- [🔎 Entries query](#🔎-entries-query)
 
 ### 🏷 Custom index name
 
@@ -373,59 +373,33 @@ module.exports = {
 
 [See resources](./resources/meilisearch-settings) for more settings examples.
 
-### 👥 Populate entry rule
+### 🔎 Entries query
 
-Content-types in Strapi may have relationships with other content-types (ex: `restaurant` can have a many-to-many relation with `category`). To ensure that these links are fetched and added to an entry correctly from your Strapi database, the correct populate rule must be provided ([see documentation](https://docs-next.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/populate.html#basic-populating)).
+When indexing a content-type to Meilisearch, the plugin has to fetch the documents from your database. With `entriesQuery` it is possible to specify some options that should be apply during the fetching of the entries.
+The options that you can set are described in the [`findMany` documentation](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findmany) of Strapi. However, we do not accept any changes on the `start` parameter.
 
-To communicate the populate rule, use the `populateEntryRule` setting on the according content-type in the plugin's settings.
+If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` can also be added in `entriesQuery`.
 
 **For example**
 
-Imagine my `restaurant` content-type has a relation with a repeatable-component `repeatableComponent` that itself has a relationship with the content-type `categories`.
-
-The following population will ensure that a `restaurant` entry contains even the most nested relation.
+For example, if you want your documents to be fetched in batches of `1000` you specify it in the `entriesQuery` option.
 
 ```js
 module.exports = {
   meilisearch: {
     config: {
       restaurant: {
-        populateEntryRule: ['repeatableComponent.categories', 'categories'],
+        entriesQuery: {
+          limit: 1000
+        }
       }
     }
   },
 }
 ```
 
-by providing this, the following is indexed in Meilisearch:
+[See resources](./resources/entries-query) for more entriesQuery examples.
 
-```json
-  {
-    "id": "restaurant-1",
-    "title": "The slimmy snail",
-    // ... other restaurant fields
-    "repeatableComponent": [
-      {
-        "id": 1,
-        "title": "my repeatable component 1"
-        "categories": [
-          {
-            "id": 3,
-            "name": "Asian",
-            // ... other category fields
-          },
-          {
-            "id": 2,
-            "name": "Healthy",
-            // ... other category fields
-          }
-        ],
-
-      }
-    ],
-
-  }
-```
 
 ### 🕵️‍♀️ Start Searching <!-- omit in toc -->
 

--- a/playground/config/plugins.js
+++ b/playground/config/plugins.js
@@ -6,6 +6,7 @@ module.exports = ({ env }) => ({
     resolve: path.resolve(__dirname, '../src/plugins/meilisearch'),
     config: {
       restaurant: {
+        entriesQuery: {},
         filterEntry({ entry }) {
           return entry.id !== 2
         },
@@ -26,8 +27,8 @@ module.exports = ({ env }) => ({
       homepage: {
         indexName: "content",
       },
-      // host: "http://localhost:7700",
-      // apiKey: "masterKey"
+      host: "http://localhost:7700",
+      apiKey: "masterKey"
     }
   }
 });

--- a/playground/config/plugins.js
+++ b/playground/config/plugins.js
@@ -6,7 +6,6 @@ module.exports = ({ env }) => ({
     resolve: path.resolve(__dirname, '../src/plugins/meilisearch'),
     config: {
       restaurant: {
-        entriesQuery: {},
         filterEntry({ entry }) {
           return entry.id !== 2
         },
@@ -27,8 +26,8 @@ module.exports = ({ env }) => ({
       homepage: {
         indexName: "content",
       },
-      host: "http://localhost:7700",
-      apiKey: "masterKey"
+      // host: "http://localhost:7700",
+      // apiKey: "masterKey"
     }
   }
 });

--- a/resources/entries-query/locale.js
+++ b/resources/entries-query/locale.js
@@ -1,0 +1,10 @@
+// All entries in every language are indexed in Meilisearch.
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        locale: 'all',
+      },
+    },
+  },
+}

--- a/resources/entries-query/populate.js
+++ b/resources/entries-query/populate.js
@@ -1,0 +1,34 @@
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        populateEntryRule: ['repeatableComponent.categories', 'categories'],
+      },
+    },
+  },
+}
+
+// The following document structure is indexed in Meilisearch
+const documents = {
+  id: 'restaurant-1',
+  title: 'The slimmy snail',
+  // ... other restaurant fields
+  repeatableComponent: [
+    {
+      id: 1,
+      title: 'my repeatable component 1',
+      categories: [
+        {
+          id: 3,
+          name: 'Asian',
+          // ... other category fields
+        },
+        {
+          id: 2,
+          name: 'Healthy',
+          // ... other category fields
+        },
+      ],
+    },
+  ],
+}

--- a/resources/entries-query/populate.js
+++ b/resources/entries-query/populate.js
@@ -2,7 +2,9 @@ module.exports = {
   meilisearch: {
     config: {
       restaurant: {
-        populateEntryRule: ['repeatableComponent.categories', 'categories'],
+        entriesQuery: {
+          populate: ['repeatableComponent.categories', 'categories'],
+        },
       },
     },
   },

--- a/resources/entries-query/populate.js
+++ b/resources/entries-query/populate.js
@@ -11,26 +11,26 @@ module.exports = {
 }
 
 // The following document structure is indexed in Meilisearch
-const documents = {
-  id: 'restaurant-1',
-  title: 'The slimmy snail',
-  // ... other restaurant fields
-  repeatableComponent: [
-    {
-      id: 1,
-      title: 'my repeatable component 1',
-      categories: [
-        {
-          id: 3,
-          name: 'Asian',
-          // ... other category fields
-        },
-        {
-          id: 2,
-          name: 'Healthy',
-          // ... other category fields
-        },
-      ],
-    },
-  ],
-}
+// {
+//   id: 'restaurant-1',
+//   title: 'The slimmy snail',
+//   // ... other restaurant fields
+//   repeatableComponent: [
+//     {
+//       id: 1,
+//       title: 'my repeatable component 1',
+//       categories: [
+//         {
+//           id: 3,
+//           name: 'Asian',
+//           // ... other category fields
+//         },
+//         {
+//           id: 2,
+//           name: 'Healthy',
+//           // ... other category fields
+//         },
+//       ],
+//     },
+//   ],
+// }

--- a/resources/entries-query/publication-state.js
+++ b/resources/entries-query/publication-state.js
@@ -1,0 +1,10 @@
+// Both published and draft entries are added in Meilisearch
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        publicationState: 'preview',
+      },
+    },
+  },
+}

--- a/server/__mocks__/meilisearch.js
+++ b/server/__mocks__/meilisearch.js
@@ -2,7 +2,7 @@ const addDocumentsMock = jest.fn(() => 10)
 const updateDocumentsMock = jest.fn(() => 10)
 const updateSettingsMock = jest.fn(() => 10)
 const deleteDocuments = jest.fn(() => {
-  return [{ uid: 1 }, { uid: 2 }]
+  return [{ taskUid: 1 }, { taskUid: 2 }]
 })
 const getIndexes = jest.fn(() => {
   return { results: [{ uid: 'my_restaurant' }, { uid: 'restaurant' }] }

--- a/server/__mocks__/meilisearch.js
+++ b/server/__mocks__/meilisearch.js
@@ -1,10 +1,10 @@
 const addDocumentsMock = jest.fn(() => 10)
+const updateDocumentsMock = jest.fn(() => 10)
 const updateSettingsMock = jest.fn(() => 10)
 const deleteDocuments = jest.fn(() => {
   return [{ uid: 1 }, { uid: 2 }]
 })
 const getIndexes = jest.fn(() => {
-  console.log('plouf')
   return { results: [{ uid: 'my_restaurant' }, { uid: 'restaurant' }] }
 })
 
@@ -24,6 +24,7 @@ const getStats = jest.fn(() => {
 
 const mockIndex = jest.fn(() => ({
   addDocuments: addDocumentsMock,
+  updateDocuments: updateDocumentsMock,
   updateSettings: updateSettingsMock,
   deleteDocuments,
   getStats,

--- a/server/__mocks__/meilisearch.js
+++ b/server/__mocks__/meilisearch.js
@@ -1,0 +1,41 @@
+const addDocumentsMock = jest.fn(() => 10)
+const updateSettingsMock = jest.fn(() => 10)
+const deleteDocuments = jest.fn(() => {
+  return [{ uid: 1 }, { uid: 2 }]
+})
+const getIndexes = jest.fn(() => {
+  console.log('plouf')
+  return { results: [{ uid: 'my_restaurant' }, { uid: 'restaurant' }] }
+})
+
+const getTasks = jest.fn(() => {
+  return {
+    results: [
+      { uid: 1, status: 'enqueued', indexUid: 'restaurant' },
+      { uid: 2, status: 'processed', indexUid: 'restaurant' },
+      { uid: 3, status: 'enqueued', indexUid: 'about' },
+    ],
+  }
+})
+
+const getStats = jest.fn(() => {
+  return { numberOfDocuments: 1, isIndexing: false, fieldDistribution: {} }
+})
+
+const mockIndex = jest.fn(() => ({
+  addDocuments: addDocumentsMock,
+  updateSettings: updateSettingsMock,
+  deleteDocuments,
+  getStats,
+}))
+
+// @ts-ignore
+const mock = jest.fn().mockImplementation(() => {
+  return {
+    getIndexes,
+    index: mockIndex,
+    getTasks,
+  }
+})
+
+module.exports = { MeiliSearch: mock }

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -747,7 +747,7 @@ describe('Test entriesQuery configuration', () => {
     })
 
     expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'The "random" option in "queryOptions" of "restaurant" is not a known option. Skipping.'
+      'The "random" option in "queryOptions" of "restaurant" is not a known option. Check the "findMany" API references in the Strapi Documentation.'
     )
 
     expect(configuration.restaurant.entriesQuery.random).toBeUndefined()

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -245,52 +245,6 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
   })
 
-  test('Test populateEntryRule with wrong type', async () => {
-    validatePluginConfig({
-      restaurant: {
-        populateEntryRule: 0,
-      },
-    })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'The "populateEntryRule" option of "restaurant" should be an object/array/string'
-    )
-  })
-
-  test('Test populateEntryRule with function', async () => {
-    validatePluginConfig({
-      restaurant: {
-        populateEntryRule: () => {},
-      },
-    })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
-      'The "populateEntryRule" option of "restaurant" should be an object/array/string'
-    )
-  })
-
-  test('Test populateEntryRule with empty object', async () => {
-    validatePluginConfig({
-      restaurant: {
-        populateEntryRule: {},
-      },
-    })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
-  })
-
-  test('Test populateEntryRule with undefined', async () => {
-    validatePluginConfig({
-      restaurant: {
-        populateEntryRule: undefined,
-      },
-    })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
-  })
-
   test('Test configuration with random field ', async () => {
     validatePluginConfig({
       restaurant: {
@@ -302,5 +256,500 @@ describe('Test plugin configuration', () => {
     expect(fakeStrapi.log.warn).toHaveBeenCalledWith(
       'The "random" option of "restaurant" is not a known option'
     )
+  })
+})
+
+describe('Test entriesQuery configuration', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  // ENTRIES QUERY
+  test('entriesQuery as number should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: 0,
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "entriesQuery" option of "restaurant" should be an object'
+    )
+  })
+
+  test('entriesQuery as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: undefined,
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toBeUndefined()
+  })
+
+  test('entriesQuery as object should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {},
+      },
+    })
+
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  // FIELDS
+  test('fields as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          fields: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('fields as array of string should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          fields: ['test'],
+        },
+      },
+    })
+
+    expect(configuration.restaurant.entriesQuery).toEqual({ fields: ['test'] })
+  })
+
+  test('fields as a none-array of string should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          fields: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "fields" option in "queryOptions" of "restaurant" should be an array of strings.'
+    )
+  })
+
+  // FILTERS
+  test('filters as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          filters: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('filters as an object should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          filters: {},
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ filters: {} })
+  })
+
+  test('Filters as a none-object should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          filters: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "filters" option in "queryOptions" of "restaurant" should be an object.'
+    )
+  })
+
+  // START
+  test('Presence of start option should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          start: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "start" option in "queryOptions" of "restaurant" is forbidden.'
+    )
+  })
+
+  // LIMIT
+  test('limit as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          limit: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('limit as a number higher than 1 should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          limit: 1,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ limit: 1 })
+  })
+
+  test('limit at 0 should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          limit: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "limit" option in "queryOptions" of "restaurant" should be a number higher than 0.'
+    )
+  })
+
+  test('limit as a none-number should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          limit: 'a',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "limit" option in "queryOptions" of "restaurant" should be a number higher than 0.'
+    )
+  })
+
+  // SORT
+  test('sort as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          sort: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('sort as an object should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          sort: {},
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ sort: {} })
+  })
+
+  test('sort as a string should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          sort: 'a',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ sort: 'a' })
+  })
+
+  test('sort as an array of strings should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          sort: ['a'],
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ sort: ['a'] })
+  })
+
+  test('sort as a none-object should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          sort: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "sort" option in "queryOptions" of "restaurant" should be an object/array/string.'
+    )
+  })
+
+  // POPULATE
+  test('populate as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          populate: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('populate as an object should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          populate: {},
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ populate: {} })
+  })
+
+  test('populate as a string should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          populate: 'a',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ populate: 'a' })
+  })
+
+  test('populate as an array of strings should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          populate: ['a'],
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({ populate: ['a'] })
+  })
+
+  test('populate as a none-object should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          populate: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "populate" option in "queryOptions" of "restaurant" should be an object/array/string.'
+    )
+  })
+
+  // PUBLICATION STATE
+
+  test('publicationState as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          publicationState: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('publicationState as "live" should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          publicationState: 'live',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({
+      publicationState: 'live',
+    })
+  })
+
+  test('publicationState as "preview" should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          publicationState: 'preview',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({
+      publicationState: 'preview',
+    })
+  })
+
+  test('publicationState a none accepted string value should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          publicationState: 'incorrect',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "publicationState" option in "queryOptions" of "restaurant" should be either "preview" or "live".'
+    )
+  })
+
+  test('publicationState as a none-string should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          publicationState: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "publicationState" option in "queryOptions" of "restaurant" should be either "preview" or "live".'
+    )
+  })
+
+  // Locale
+  test('locale as undefined should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          locale: undefined,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({})
+  })
+
+  test('locale as "all" should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          locale: 'all',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({
+      locale: 'all',
+    })
+  })
+
+  test('locale as a random string should succeed', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          locale: 'random',
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
+    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.entriesQuery).toEqual({
+      locale: 'random',
+    })
+  })
+
+  test('locale as a none-string should log error', async () => {
+    validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          locale: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "locale" option in "queryOptions" of "restaurant" should be a non-empty string.'
+    )
+  })
+
+  // UNKNOWN FIELDS
+
+  test('Unknown fields in entriesQuery should log a warning', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        entriesQuery: {
+          random: 0,
+        },
+      },
+    })
+
+    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+      'The "random" option in "queryOptions" of "restaurant" is not a known option. Skipping.'
+    )
+
+    expect(configuration.restaurant.entriesQuery.random).toBeUndefined()
   })
 })

--- a/server/__tests__/configuration.test.js
+++ b/server/__tests__/configuration.test.js
@@ -292,13 +292,9 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration to remove unpublished entries', async () => {
-    const customStrapi = createFakeStrapi({
-      restaurantConfig: {},
-    })
-
     const contentType = 'restaurant'
     const meilisearchService = createMeilisearchService({
-      strapi: customStrapi,
+      strapi: fakeStrapi,
     })
 
     const entries = meilisearchService.removeUnpublishedArticles({

--- a/server/__tests__/configuration.test.js
+++ b/server/__tests__/configuration.test.js
@@ -293,8 +293,31 @@ describe('Test Meilisearch plugin configurations', () => {
 
   test('Test configuration to remove unpublished entries', async () => {
     const customStrapi = createFakeStrapi({
+      restaurantConfig: {},
+    })
+
+    const contentType = 'restaurant'
+    const meilisearchService = createMeilisearchService({
+      strapi: customStrapi,
+    })
+
+    const entries = meilisearchService.removeUnpublishedArticles({
+      contentType,
+      entries: [
+        { id: 1, publishedAt: null },
+        { id: 2, publishedAt: null },
+      ],
+    })
+
+    expect(entries).toEqual([])
+  })
+
+  test('Test configuration to unwanted locale entries', async () => {
+    const customStrapi = createFakeStrapi({
       restaurantConfig: {
-        transformEntry: () => {},
+        entriesQuery: {
+          locale: 'fr',
+        },
       },
     })
 
@@ -302,16 +325,16 @@ describe('Test Meilisearch plugin configurations', () => {
     const meilisearchService = createMeilisearchService({
       strapi: customStrapi,
     })
-    const indexName = meilisearchService.getIndexNameOfContentType({
+
+    const entries = meilisearchService.removeLocaleEntries({
       contentType,
-    })
-    const entries = meilisearchService.removeUnpublishedArticles({
-      contentType,
-      entries: [{ id: 1 }, { id: 2 }],
+      entries: [
+        { id: 1, locale: 'fr' },
+        { id: 2, locale: 'en' },
+      ],
     })
 
-    expect(indexName).toEqual(contentType)
-    expect(entries).toEqual([])
+    expect(entries).toEqual([{ id: 1, locale: 'fr' }])
   })
 
   test('Test configuration to keep unpublished entries', async () => {
@@ -333,11 +356,17 @@ describe('Test Meilisearch plugin configurations', () => {
     })
     const entries = meilisearchService.removeUnpublishedArticles({
       contentType,
-      entries: [{ id: 1 }, { id: 2 }],
+      entries: [
+        { id: 1, publishedAt: null },
+        { id: 2, publishedAt: null },
+      ],
     })
 
     expect(indexName).toEqual(contentType)
-    expect(entries).toEqual([{ id: 1 }, { id: 2 }])
+    expect(entries).toEqual([
+      { id: 1, publishedAt: null },
+      { id: 2, publishedAt: null },
+    ])
   })
 
   test('Test configuration with empty settings ', async () => {

--- a/server/__tests__/configuration.test.js
+++ b/server/__tests__/configuration.test.js
@@ -308,7 +308,7 @@ describe('Test Meilisearch plugin configurations', () => {
     expect(entries).toEqual([])
   })
 
-  test('Test configuration to unwanted locale entries', async () => {
+  test('Test should remove unwanted entries with a specific language', async () => {
     const customStrapi = createFakeStrapi({
       restaurantConfig: {
         entriesQuery: {
@@ -333,7 +333,7 @@ describe('Test Meilisearch plugin configurations', () => {
     expect(entries).toEqual([{ id: 1, locale: 'fr' }])
   })
 
-  test('Test configuration to keep unpublished entries', async () => {
+  test('Test should keep unpublished entries when publicationState is set to preview', async () => {
     const customStrapi = createFakeStrapi({
       restaurantConfig: {
         transformEntry: () => {},
@@ -472,6 +472,4 @@ describe('Test Meilisearch plugin configurations', () => {
 
     expect(contentTypes).toEqual(['restaurant', 'about'])
   })
-
-  // TODO: add tests here
 })

--- a/server/__tests__/content-types.test.js
+++ b/server/__tests__/content-types.test.js
@@ -198,9 +198,11 @@ describe('Tests content types', () => {
     const entry = await contentTypeServices.getEntry({
       contentType: 'api::restaurant.restaurant',
       id: 200,
-      fields: ['title'],
-      populate: {
-        subClass: true,
+      entriesQuery: {
+        fields: ['title'],
+        populate: {
+          subClass: true,
+        },
       },
     })
 

--- a/server/__tests__/meilisearch.test.js
+++ b/server/__tests__/meilisearch.test.js
@@ -71,4 +71,42 @@ describe('Tests content types', () => {
       fieldDistribution: {},
     })
   })
+
+  test('Test to update the content of a collection in Meilisearch', async () => {
+    const customStrapi = createFakeStrapi({
+      restaurantConfig: {
+        entriesQuery: {
+          limit: 1,
+          fields: ['id'],
+          filters: {},
+          sort: {},
+          populate: [],
+          publicationState: 'preview',
+        },
+      },
+    })
+
+    const meilisearchService = createMeilisearchService({
+      strapi: customStrapi,
+    })
+
+    await meilisearchService.addContentTypeInMeiliSearch({
+      contentType: 'restaurant',
+    })
+
+    expect(
+      customStrapi.plugin().service().actionInBatches
+    ).toHaveBeenCalledWith({
+      contentType: 'restaurant',
+      callback: expect.anything(),
+      entriesQuery: {
+        limit: 1,
+        fields: ['id'],
+        filters: {},
+        sort: {},
+        populate: [],
+        publicationState: 'preview',
+      },
+    })
+  })
 })

--- a/server/__tests__/meilisearch.test.js
+++ b/server/__tests__/meilisearch.test.js
@@ -52,7 +52,7 @@ describe('Tests content types', () => {
       'restaurant-2',
     ])
     expect(client.index).toHaveBeenCalledWith('customIndex')
-    expect(tasks).toEqual([{ uid: 1 }, { uid: 2 }])
+    expect(tasks).toEqual([{ taskUid: 1 }, { taskUid: 2 }])
   })
 
   test('Test to get stats', async () => {

--- a/server/__tests__/utils/fakes.js
+++ b/server/__tests__/utils/fakes.js
@@ -17,16 +17,29 @@ function createFakeStrapi({
     service: fakePluginService,
   }))
 
-  const fakePluginService = jest.fn(() => ({
-    getContentTypesUid: () => ['restaurant', 'about'],
-    getCollectionName: ({ contentType }) => contentType,
-    getCredentials: () => ({
-      host: 'http://localhost:7700',
-      apiKey: 'masterKey',
-      ApiKeyIsFromConfigFile: true,
-      HostIsFromConfigFile: true,
-    }),
-  }))
+  const fakeActionInBatches = jest.fn(() => {
+    return [{ id: '1' }]
+  })
+
+  const fakeAddIndexedContentType = jest.fn(() => {})
+
+  const fakePluginService = jest.fn(() => {
+    return {
+      getContentTypesUid: () => ['restaurant', 'about'],
+      getCollectionName: ({ contentType }) => contentType,
+      getCredentials: () => ({
+        host: 'http://localhost:7700',
+        apiKey: 'masterKey',
+        ApiKeyIsFromConfigFile: true,
+        HostIsFromConfigFile: true,
+      }),
+      actionInBatches: fakeActionInBatches,
+      addIndexedContentType: fakeAddIndexedContentType,
+      subscribeContentType: () => {
+        return
+      },
+    }
+  })
 
   const fakeLogger = {
     error: jest.fn(() => {}),

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -154,7 +154,7 @@ function EntriesQuery({ configuration, collectionName }) {
       // Unknown fields
       Object.keys(unknownKeys).map(key => {
         log.error(
-          `The "${key}" option in "queryOptions" of "${collectionName}" is not a known option. Skipping.`
+          `The "${key}" option in "queryOptions" of "${collectionName}" is not a known option. Check the "findMany" API references in the Strapi Documentation.`
         )
       })
 

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -1,4 +1,171 @@
 const { isObject } = require('./utils')
+/**
+ * Validate and cleans the DB query settings.
+ * These will be used when fetching documents from the user's database.
+ *
+ *
+ * @param  {object} options
+ * @param  {string} options.collectionName
+ * @param  {object} options.configuration
+ * @param  {string[]} options.configuration.fields
+ * @param  {any} options.configuration.filters
+ * @param  {number} options.configuration.start
+ * @param  {number} options.configuration.limit
+ * @param  {any} options.configuration.sort
+ * @param  {any} options.configuration.populate
+ * @param  {any} options.configuration.publicationState
+ * @param  {any} options.configuration.locale
+ *
+ * @returns {object} - All validating functions
+ *
+ */
+function EntriesQuery({ configuration, collectionName }) {
+  const log = strapi.log // has to be inside a scope
+  const {
+    fields,
+    filters,
+    start,
+    limit,
+    sort,
+    populate,
+    publicationState,
+    locale,
+    ...unknownKeys
+  } = configuration
+
+  const options = {}
+
+  return {
+    validateFields() {
+      if (fields !== undefined && !Array.isArray(fields)) {
+        log.error(
+          `The "fields" option in "queryOptions" of "${collectionName}" should be an array of strings.`
+        )
+      } else if (fields !== undefined) {
+        options.fields = fields
+      }
+
+      return this
+    },
+
+    validateFilters() {
+      if (filters !== undefined && !isObject(filters)) {
+        log.error(
+          `The "filters" option in "queryOptions" of "${collectionName}" should be an object.`
+        )
+      } else if (filters !== undefined) {
+        options.filters = filters
+      }
+
+      return this
+    },
+
+    validateStart() {
+      if (start !== undefined) {
+        log.error(
+          `The "start" option in "queryOptions" of "${collectionName}" is forbidden.`
+        )
+      }
+
+      return this
+    },
+
+    validateLimit() {
+      if (limit !== undefined && (isNaN(limit) || limit < 1)) {
+        log.error(
+          `The "limit" option in "queryOptions" of "${collectionName}" should be a number higher than 0.`
+        )
+      } else if (limit !== undefined) {
+        options.limit = limit
+      }
+
+      return this
+    },
+
+    validateSort() {
+      // Sort is either undefined or an object/array/string
+      if (
+        sort !== undefined &&
+        !isObject(sort) &&
+        !Array.isArray(sort) &&
+        typeof sort !== 'string'
+      ) {
+        log.error(
+          `The "sort" option in "queryOptions" of "${collectionName}" should be an object/array/string.`
+        )
+      } else if (sort !== undefined) {
+        options.sort = sort
+      }
+
+      return this
+    },
+
+    validatePopulate() {
+      // Populate is either undefined or an object/array/string
+      if (
+        populate !== undefined &&
+        !isObject(populate) &&
+        !Array.isArray(populate) &&
+        typeof populate !== 'string'
+      ) {
+        log.error(
+          `The "populate" option in "queryOptions" of "restaurant" should be an object/array/string.`
+        )
+      } else if (populate !== undefined) {
+        options.populate = populate
+      }
+
+      return this
+    },
+
+    validatePublicationState() {
+      if (
+        publicationState !== undefined &&
+        publicationState !== 'live' &&
+        publicationState !== 'preview'
+      ) {
+        log.error(
+          `The "publicationState" option in "queryOptions" of "${collectionName}" should be either "preview" or "live".`
+        )
+      } else if (publicationState !== undefined) {
+        options.publicationState = publicationState
+      }
+
+      return this
+    },
+
+    validateLocale() {
+      // locale is either undefined or a none empty string
+      if (
+        (locale !== undefined && typeof locale !== 'string') ||
+        locale === ''
+      ) {
+        log.error(
+          `The "locale" option in "queryOptions" of "${collectionName}" should be a non-empty string.`
+        )
+      } else if (locale !== undefined) {
+        options.locale = locale
+      }
+
+      return this
+    },
+
+    addUnknownKeys() {
+      // Unknown fields
+      Object.keys(unknownKeys).map(key => {
+        log.error(
+          `The "${key}" option in "queryOptions" of "${collectionName}" is not a known option. Skipping.`
+        )
+      })
+
+      return this
+    },
+
+    get() {
+      return options
+    },
+  }
+}
 
 function CollectionConfig({ collectionName, configuration }) {
   const log = strapi.log // has to be inside a scope
@@ -7,8 +174,8 @@ function CollectionConfig({ collectionName, configuration }) {
     transformEntry,
     filterEntry,
     settings,
-    populateEntryRule,
-    ...excedent
+    entriesQuery,
+    ...unknownFields
   } = configuration
   const options = {}
 
@@ -71,19 +238,26 @@ function CollectionConfig({ collectionName, configuration }) {
       return this
     },
 
-    validatePopulateEntryRule() {
-      // PopulateEntry is either undefined or an object/array/string
-      if (
-        populateEntryRule !== undefined &&
-        !isObject(populateEntryRule) &&
-        !Array.isArray(populateEntryRule) &&
-        typeof populateEntryRule !== 'string'
-      ) {
+    validateEntriesQuery() {
+      if (entriesQuery !== undefined && !isObject(entriesQuery)) {
         log.error(
-          `The "populateEntryRule" option of "${collectionName}" should be an object/array/string`
+          `The "entriesQuery" option of "${collectionName}" should be an object`
         )
-      } else if (populateEntryRule !== undefined) {
-        options.populateEntryRule = populateEntryRule
+      } else if (entriesQuery !== undefined) {
+        options.entriesQuery = EntriesQuery({
+          configuration: entriesQuery,
+          collectionName,
+        })
+          .validateFields()
+          .validateFilters()
+          .validateStart()
+          .validateLimit()
+          .validateSort()
+          .validatePopulate()
+          .validatePublicationState()
+          .validateLocale()
+          .addUnknownKeys()
+          .get()
       }
 
       return this
@@ -91,7 +265,7 @@ function CollectionConfig({ collectionName, configuration }) {
 
     validateNoInvalidKeys() {
       // Keys that should not be present in the configuration
-      Object.keys(excedent).map(key => {
+      Object.keys(unknownFields).map(key => {
         log.warn(
           `The "${key}" option of "${collectionName}" is not a known option`
         )
@@ -99,6 +273,7 @@ function CollectionConfig({ collectionName, configuration }) {
 
       return this
     },
+
     get() {
       return options
     },
@@ -148,8 +323,8 @@ function PluginConfig({ configuration }) {
             .validateFilterEntry()
             .validateTransformEntry()
             .validateMeilisearchSettings()
-            .validatePopulateEntryRule()
             .validateNoInvalidKeys()
+            .validateEntriesQuery()
             .get()
         }
       }
@@ -188,6 +363,8 @@ function validatePluginConfig(configuration) {
     .get()
 
   Object.assign(configuration, options)
+
+  return configuration
 }
 
 module.exports = {

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -184,7 +184,7 @@ module.exports = ({ strapi }) => ({
       filters,
       sort,
       populate,
-      publicationState: publicationState,
+      publicationState,
     })
     // Safe guard in case the content-type is a single type.
     // In which case it is wrapped in an array for consistency.
@@ -197,7 +197,7 @@ module.exports = ({ strapi }) => ({
    *
    * @param  {object} options
    * @param  {string} options.contentType - Name of the content type.
-   * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
+   * @param  {object} [options.entriesQuery] - Options to apply when fetching entries from the database.
    * @param  {function} options.callback - Function applied on each entry of the contentType.
    *
    * @returns {Promise<any[]>} - List of all the returned elements from the callback.
@@ -205,22 +205,20 @@ module.exports = ({ strapi }) => ({
   actionInBatches: async function ({
     contentType,
     callback = () => {},
-    populate = '*',
+    entriesQuery = {},
   }) {
-    const BATCH_SIZE = 500
-
+    const batchSize = entriesQuery.limit || 500
     // Need total number of entries in contentType
     const entries_count = await this.numberOfEntries({
       contentType,
     })
     const cbResponse = []
-    for (let index = 0; index <= entries_count; index += BATCH_SIZE) {
+    for (let index = 0; index <= entries_count; index += batchSize) {
       const entries =
         (await this.getEntries({
           start: index,
-          limit: BATCH_SIZE,
           contentType,
-          populate,
+          ...entriesQuery,
         })) || []
 
       const info = await callback({ entries, contentType })

--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -126,13 +126,16 @@ module.exports = ({ strapi }) => ({
    *
    * @param  {object} options
    * @param  {string | number} [options.id] - Id of the entry.
-   * @param  {string | string[]} [options.fields] - Fields present in the returned entry.
-   * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
-   * @param  {string} [options.contentType] - Content type.
+   * @param  {object} [options.entriesQuery={}] - Options to apply when fetching entries from the database.
+   * @param  {string | string[]} [options.entriesQuery.fields] - Fields present in the returned entry.
+   * @param  {object} [options.entriesQuery.populate] - Relations, components and dynamic zones to populate.
+   * @param  {object} [options.entriesQuery.locale] - When using internalization, the language to fetch.
+   * @param  {string} options.contentType - Content type.
    *
    * @returns  {Promise<object>} - Entries.
    */
-  async getEntry({ contentType, id, fields = '*', populate = '*' }) {
+  async getEntry({ contentType, id, entriesQuery = {} }) {
+    const { populate = '*', fields = '*' } = entriesQuery
     const contentTypeUid = this.getContentTypeUid({ contentType })
     if (contentTypeUid === undefined) return {}
 
@@ -160,7 +163,7 @@ module.exports = ({ strapi }) => ({
    * @param  {object|string} [options.sort] - Order definition.
    * @param  {object} [options.populate] - Relations, components and dynamic zones to populate.
    * @param  {object} [options.publicationState] - Publication state: live or preview.
-   * @param  {string} [options.contentType] - Content type.
+   * @param  {string} options.contentType - Content type.
    * @param  {string} [options.locale] - When using internalization, the language to fetch.
    *
    * @returns  {Promise<object[]>} - Entries.

--- a/server/services/lifecycle/lifecycle.js
+++ b/server/services/lifecycle/lifecycle.js
@@ -28,7 +28,7 @@ module.exports = ({ strapi }) => {
           const entry = await contentTypeService.getEntry({
             contentType: contentTypeUid,
             id: result.id,
-            populate: meilisearch.populateEntryRule({ contentType }),
+            entriesQuery: meilisearch.entriesQuery({ contentType }),
           })
 
           meilisearch
@@ -58,7 +58,7 @@ module.exports = ({ strapi }) => {
           const entry = await contentTypeService.getEntry({
             contentType: contentTypeUid,
             id: result.id,
-            populate: meilisearch.populateEntryRule({ contentType }),
+            entriesQuery: meilisearch.entriesQuery({ contentType }),
           })
 
           meilisearch

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -215,7 +215,31 @@ module.exports = ({ strapi }) => {
       if (entriesQuery.publicationState === 'preview') {
         return entries
       } else {
-        return entries.filter(entry => !(entry.publishedAt == null))
+        return entries.filter(entry => !(entry.publishedAt === null))
+      }
+    },
+
+    /**
+     * Remove language entries.
+     * In the plugin entriesQuery, if `locale` is set and not equal to `all`
+     * all entries that do not have the specified language are removed.
+     *
+     * @param {object} options
+     * @param {Array<Object>} options.entries - The entries to filter.
+     * @param {string} options.contentType - ContentType name.
+     *
+     * @return {Array<Object>} - Published entries.
+     */
+    removeLocaleEntries: function ({ entries, contentType }) {
+      const collection = contentTypeService.getCollectionName({ contentType })
+      const contentTypeConfig = meilisearchConfig[collection] || {}
+
+      const entriesQuery = contentTypeConfig.entriesQuery || {}
+
+      if (!entriesQuery.locale || entriesQuery.locale === 'all') {
+        return entries
+      } else {
+        return entries.filter(entry => entry.locale === entriesQuery.locale)
       }
     },
   }

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -51,6 +51,21 @@ module.exports = ({ strapi }) => {
     },
 
     /**
+     * Get the entries query rule of a content-type that are applied when fetching entries in the Strapi database.
+     *
+     * @param {object} options
+     * @param {string} options.contentType - ContentType name.
+     *
+     * @return {String} - EntriesQuery rules.
+     */
+    entriesQuery: function ({ contentType }) {
+      const collection = contentTypeService.getCollectionName({ contentType })
+      const contentTypeConfig = meilisearchConfig[collection] || {}
+
+      return contentTypeConfig.entriesQuery || {}
+    },
+
+    /**
      * Transform contentTypes entries before indexation in Meilisearch.
      *
      * @param {object} options

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -36,21 +36,6 @@ module.exports = ({ strapi }) => {
     },
 
     /**
-     * Get the populate rule of a content-type that is applied when fetching entries in the Strapi database.
-     *
-     * @param {object} options
-     * @param {string} options.contentType - ContentType name.
-     *
-     * @return {String} - Populate rule.
-     */
-    populateEntryRule: function ({ contentType }) {
-      const collection = contentTypeService.getCollectionName({ contentType })
-      const contentTypeConfig = meilisearchConfig[collection] || {}
-
-      return contentTypeConfig.populateEntryRule || '*'
-    },
-
-    /**
      * Get the entries query rule of a content-type that are applied when fetching entries in the Strapi database.
      *
      * @param {object} options

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -212,16 +212,26 @@ module.exports = ({ strapi }) => {
     },
 
     /**
-     * Remove unpublished entries from array of entries.
+     * Remove unpublished entries from array of entries
+     * unless `publicationState` is set to true.
      *
      * @param {object} options
      * @param {Array<Object>} options.entries - The entries to filter.
-     *
+     * @param {string} options.contentType - ContentType name.
      *
      * @return {Array<Object>} - Published entries.
      */
-    removeUnpublishedArticles: function ({ entries }) {
-      return entries.filter(entry => !(entry.publishedAt === null))
+    removeUnpublishedArticles: function ({ entries, contentType }) {
+      const collection = contentTypeService.getCollectionName({ contentType })
+      const contentTypeConfig = meilisearchConfig[collection] || {}
+
+      const entriesQuery = contentTypeConfig.entriesQuery || {}
+
+      if (entriesQuery.publicationState === 'preview') {
+        return entries
+      } else {
+        return entries.filter(entry => !(entry.publishedAt == null))
+      }
     },
   }
 }

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -25,6 +25,12 @@ const sanitizeEntries = async function ({
     entries,
   })
 
+  // remove entries with unwanted locale language
+  entries = await config.removeLocaleEntries({
+    contentType,
+    entries,
+  })
+
   // Apply filterEntry plugin config.
   entries = await config.filterEntries({
     contentType,

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -286,7 +286,7 @@ module.exports = ({ strapi, adapter, config }) => {
       const tasksUids = await contentTypeService.actionInBatches({
         contentType,
         callback: addDocuments,
-        populate: config.populateEntryRule({ contentType }),
+        entriesQuery: config.entriesQuery({ contentType }),
       })
 
       await store.addIndexedContentType({ contentType })
@@ -345,7 +345,7 @@ module.exports = ({ strapi, adapter, config }) => {
         await contentTypeService.actionInBatches({
           contentType,
           callback: deleteEntries,
-          populate: config.populateEntryRule({ contentType }),
+          entriesQuery: config.entriesQuery({ contentType }),
         })
       } else {
         const { apiKey, host } = await store.getCredentials()

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -21,6 +21,7 @@ const sanitizeEntries = async function ({
 
   // remove un-published entries
   entries = await config.removeUnpublishedArticles({
+    contentType,
     entries,
   })
 
@@ -115,7 +116,7 @@ module.exports = ({ strapi, adapter, config }) => {
           config,
           adapter,
         })
-        if (entry.publishedAt === null || sanitized.length === 0) {
+        if (sanitized.length === 0) {
           return client.index(indexUid).deleteDocument(
             adapter.addCollectionNamePrefixToId({
               contentType,


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #536 
Fixes #263 
Fixes #85

## What does this PR do?

A lot of users were asking for more control over what entries are indexed in Meilisearch and how.
For example:
- the batch sizes which has a default value of 500.
- the `locale` support to fetch all entries of every language

This PR adds a new setting `entriesQuery` that lets you set exactly how Meilisearch should fetch documents from your database. These options are provided directly by the `findMany` API of strapi ([see doc](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/entity-service/crud.html#findmany)).

Further explanation on how it works isn provided in the README of this PR.

## ❌ Breaking changes

The setting `populateEntryRule` in the plugin configuration is removed in favor of `populate` in `entriesQuery`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
