### PR TITLE
Rename mocking variables

### DIFF
--- a/server/__mocks__/strapi.js
+++ b/server/__mocks__/strapi.js
@@ -1,4 +1,4 @@
-const defaultContentTypes = require('./content-types-list')
+const defaultContentTypes = require('../__tests__/utils/content-types-list')
 
 /**
  * @param {object} config
@@ -6,24 +6,24 @@ const defaultContentTypes = require('./content-types-list')
  * @param  {object} [config.aboutConfig]
  * @param  {object} [config.contentTypes]
  */
-function createFakeStrapi({
+function createStrapiMock({
   restaurantConfig = {},
   aboutConfig = {},
   contentTypes,
 }) {
   contentTypes = contentTypes || defaultContentTypes
 
-  const fakePlugin = jest.fn(() => ({
-    service: fakePluginService,
+  const mockPlugin = jest.fn(() => ({
+    service: mockPluginService,
   }))
 
-  const fakeActionInBatches = jest.fn(() => {
+  const mockActionInBatches = jest.fn(() => {
     return [{ id: '1' }]
   })
 
-  const fakeAddIndexedContentType = jest.fn(() => {})
+  const mockAddIndexedContentType = jest.fn(() => {})
 
-  const fakePluginService = jest.fn(() => {
+  const mockPluginService = jest.fn(() => {
     return {
       getContentTypesUid: () => ['restaurant', 'about'],
       getCollectionName: ({ contentType }) => contentType,
@@ -33,20 +33,20 @@ function createFakeStrapi({
         ApiKeyIsFromConfigFile: true,
         HostIsFromConfigFile: true,
       }),
-      actionInBatches: fakeActionInBatches,
-      addIndexedContentType: fakeAddIndexedContentType,
+      actionInBatches: mockActionInBatches,
+      addIndexedContentType: mockAddIndexedContentType,
       subscribeContentType: () => {
         return
       },
     }
   })
 
-  const fakeLogger = {
+  const mockLogger = {
     error: jest.fn(() => {}),
     warn: jest.fn(() => {}),
   }
 
-  const fakeConfig = {
+  const mockConfig = {
     get: jest.fn(() => {
       return {
         restaurant: restaurantConfig,
@@ -55,39 +55,39 @@ function createFakeStrapi({
     }),
   }
 
-  const fakeFindWithCount = jest.fn(() => {
+  const mockFindWithCount = jest.fn(() => {
     return 1
   })
-  const fakeDb = {
+  const mockDb = {
     query: jest.fn(() => ({
-      count: fakeFindWithCount,
+      count: mockFindWithCount,
     })),
   }
 
-  const fakeFindMany = jest.fn(() => {
+  const mockFindMany = jest.fn(() => {
     return [{ id: 1 }]
   })
 
-  const fakeFindOne = jest.fn(() => {
+  const mockFindOne = jest.fn(() => {
     return [{ id: 1 }]
   })
 
-  const fakeEntityService = {
-    findMany: fakeFindMany,
-    findOne: fakeFindOne,
+  const mockEntityService = {
+    findMany: mockFindMany,
+    findOne: mockFindOne,
   }
 
-  const fakeStrapi = {
-    log: fakeLogger,
-    plugin: fakePlugin,
+  const mockStrapi = {
+    log: mockLogger,
+    plugin: mockPlugin,
     contentTypes,
-    config: fakeConfig,
-    db: fakeDb,
-    entityService: fakeEntityService,
+    config: mockConfig,
+    db: mockDb,
+    entityService: mockEntityService,
   }
-  return fakeStrapi
+  return mockStrapi
 }
 
 module.exports = {
-  createFakeStrapi,
+  createStrapiMock,
 }

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -1,9 +1,9 @@
 const { validatePluginConfig } = require('../configuration-validation')
 
-const { createFakeStrapi } = require('./utils/fakes')
+const { createStrapiMock } = require('../__mocks__/strapi')
 
-const fakeStrapi = createFakeStrapi({})
-global.strapi = fakeStrapi
+const strapiMock = createStrapiMock({})
+global.strapi = strapiMock
 
 describe('Test plugin configuration', () => {
   beforeEach(async () => {
@@ -13,32 +13,32 @@ describe('Test plugin configuration', () => {
 
   test('Test empty configuration', async () => {
     validatePluginConfig()
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test wrong type config configuration', async () => {
     validatePluginConfig(1)
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "config" field in the Meilisearch plugin configuration should be an object'
     )
   })
 
   test('Test wrong object configuration', async () => {
     validatePluginConfig({})
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with not used attribute', async () => {
     validatePluginConfig({
       hello: 0,
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The collection "hello" configuration should be of type object'
     )
   })
@@ -47,17 +47,17 @@ describe('Test plugin configuration', () => {
     validatePluginConfig({
       host: undefined,
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with empty string host', async () => {
     validatePluginConfig({
       host: '',
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "host" option should be a non-empty string'
     )
   })
@@ -66,25 +66,25 @@ describe('Test plugin configuration', () => {
     validatePluginConfig({
       host: 'test',
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with empty apiKey', async () => {
     validatePluginConfig({
       apiKey: undefined,
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with wrong time apiKey', async () => {
     validatePluginConfig({
       apiKey: 0,
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "apiKey" option should be a string'
     )
   })
@@ -93,24 +93,24 @@ describe('Test plugin configuration', () => {
     validatePluginConfig({
       apiKey: '',
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with string apiKey', async () => {
     validatePluginConfig({
       apiKey: 'test',
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with string apiKey', async () => {
     validatePluginConfig({
       apiKey: 'test',
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test indexName with empty string', async () => {
@@ -119,9 +119,9 @@ describe('Test plugin configuration', () => {
         indexName: '',
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "indexName" option of "restaurant" should be a non-empty string'
     )
   })
@@ -132,8 +132,8 @@ describe('Test plugin configuration', () => {
         indexName: 'hello',
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test indexName with undefined', async () => {
@@ -142,8 +142,8 @@ describe('Test plugin configuration', () => {
         indexName: undefined,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test transformEntry with wrong type', async () => {
@@ -152,9 +152,9 @@ describe('Test plugin configuration', () => {
         transformEntry: 0,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "transformEntry" option of "restaurant" should be a function'
     )
   })
@@ -165,8 +165,8 @@ describe('Test plugin configuration', () => {
         transformEntry: () => {},
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test transformEntry with undefined', async () => {
@@ -175,8 +175,8 @@ describe('Test plugin configuration', () => {
         transformEntry: undefined,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test filterEntry with wrong type', async () => {
@@ -185,9 +185,9 @@ describe('Test plugin configuration', () => {
         filterEntry: 0,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "filterEntry" option of "restaurant" should be a function'
     )
   })
@@ -198,8 +198,8 @@ describe('Test plugin configuration', () => {
         filterEntry: () => {},
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test filterEntry with undefined', async () => {
@@ -208,8 +208,8 @@ describe('Test plugin configuration', () => {
         filterEntry: undefined,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test settings with wrong type', async () => {
@@ -218,9 +218,9 @@ describe('Test plugin configuration', () => {
         settings: 0,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "settings" option of "restaurant" should be an object'
     )
   })
@@ -231,8 +231,8 @@ describe('Test plugin configuration', () => {
         settings: () => {},
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
   })
 
   test('Test settings with undefined', async () => {
@@ -241,8 +241,8 @@ describe('Test plugin configuration', () => {
         settings: undefined,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
   test('Test configuration with random field ', async () => {
@@ -251,9 +251,9 @@ describe('Test plugin configuration', () => {
         random: undefined,
       },
     })
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(1)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.warn).toHaveBeenCalledWith(
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledWith(
       'The "random" option of "restaurant" is not a known option'
     )
   })
@@ -273,7 +273,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "entriesQuery" option of "restaurant" should be an object'
     )
   })
@@ -285,8 +285,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toBeUndefined()
   })
 
@@ -310,8 +310,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -336,7 +336,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "fields" option in "queryOptions" of "restaurant" should be an array of strings.'
     )
   })
@@ -351,8 +351,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -365,8 +365,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ filters: {} })
   })
 
@@ -379,7 +379,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "filters" option in "queryOptions" of "restaurant" should be an object.'
     )
   })
@@ -394,7 +394,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "start" option in "queryOptions" of "restaurant" is forbidden.'
     )
   })
@@ -409,8 +409,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -423,8 +423,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ limit: 1 })
   })
 
@@ -437,7 +437,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "limit" option in "queryOptions" of "restaurant" should be a number higher than 0.'
     )
   })
@@ -451,7 +451,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "limit" option in "queryOptions" of "restaurant" should be a number higher than 0.'
     )
   })
@@ -466,8 +466,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -480,8 +480,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ sort: {} })
   })
 
@@ -494,8 +494,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ sort: 'a' })
   })
 
@@ -508,8 +508,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ sort: ['a'] })
   })
 
@@ -522,7 +522,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "sort" option in "queryOptions" of "restaurant" should be an object/array/string.'
     )
   })
@@ -537,8 +537,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -551,8 +551,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ populate: {} })
   })
 
@@ -565,8 +565,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ populate: 'a' })
   })
 
@@ -579,8 +579,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({ populate: ['a'] })
   })
 
@@ -593,7 +593,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "populate" option in "queryOptions" of "restaurant" should be an object/array/string.'
     )
   })
@@ -609,8 +609,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -623,8 +623,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({
       publicationState: 'live',
     })
@@ -639,8 +639,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({
       publicationState: 'preview',
     })
@@ -655,7 +655,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "publicationState" option in "queryOptions" of "restaurant" should be either "preview" or "live".'
     )
   })
@@ -669,7 +669,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "publicationState" option in "queryOptions" of "restaurant" should be either "preview" or "live".'
     )
   })
@@ -684,8 +684,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({})
   })
 
@@ -698,8 +698,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({
       locale: 'all',
     })
@@ -714,8 +714,8 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.warn).toHaveBeenCalledTimes(0)
-    expect(fakeStrapi.log.error).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
     expect(configuration.restaurant.entriesQuery).toEqual({
       locale: 'random',
     })
@@ -730,7 +730,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "locale" option in "queryOptions" of "restaurant" should be a non-empty string.'
     )
   })
@@ -746,7 +746,7 @@ describe('Test entriesQuery configuration', () => {
       },
     })
 
-    expect(fakeStrapi.log.error).toHaveBeenCalledWith(
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
       'The "random" option in "queryOptions" of "restaurant" is not a known option. Check the "findMany" API references in the Strapi Documentation.'
     )
 

--- a/server/__tests__/configuration.test.js
+++ b/server/__tests__/configuration.test.js
@@ -1,10 +1,10 @@
 const createMeilisearchService = require('../services/meilisearch')
 
-const { createFakeStrapi } = require('./utils/fakes')
+const { createStrapiMock } = require('../__mocks__/strapi')
 jest.mock('meilisearch')
 
-const fakeStrapi = createFakeStrapi({})
-global.strapi = fakeStrapi
+const strapiMock = createStrapiMock({})
+global.strapi = strapiMock
 
 describe('Test Meilisearch plugin configurations', () => {
   beforeEach(async () => {
@@ -13,7 +13,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test with no meilisearch configurations', async () => {
-    const customStrapi = createFakeStrapi({})
+    const customStrapi = createStrapiMock({})
 
     const contentType = 'restaurant'
     const meilisearchService = createMeilisearchService({
@@ -37,7 +37,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test with empty meilisearch configurations', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {},
     })
 
@@ -62,7 +62,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test with wrong type meilisearch configurations', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: 1,
     })
 
@@ -87,7 +87,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration undefined indexName', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {},
     })
 
@@ -113,7 +113,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with non-empty type indexName', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         indexName: 'customName',
       },
@@ -141,7 +141,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with undefined transformEntry ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         transformEntry: undefined,
       },
@@ -168,7 +168,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with correct transformEntry ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         transformEntry: ({ entry }) => {
           return {
@@ -203,7 +203,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with correct filterEntry ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         filterEntry: ({ entry }) => {
           return entry.id !== 1
@@ -236,7 +236,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with throwing transformEntry ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         transformEntry: () => {
           throw new Error('failed')
@@ -265,7 +265,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with no return transformEntry ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         transformEntry: () => {},
       },
@@ -294,7 +294,7 @@ describe('Test Meilisearch plugin configurations', () => {
   test('Test configuration to remove unpublished entries', async () => {
     const contentType = 'restaurant'
     const meilisearchService = createMeilisearchService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const entries = meilisearchService.removeUnpublishedArticles({
@@ -309,7 +309,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test should remove unwanted entries with a specific language', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         entriesQuery: {
           locale: 'fr',
@@ -334,7 +334,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test should keep unpublished entries when publicationState is set to preview', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         transformEntry: () => {},
         entriesQuery: {
@@ -366,7 +366,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with empty settings ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         settings: {},
       },
@@ -393,7 +393,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with undefined settings ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         settings: undefined,
       },
@@ -420,7 +420,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test configuration with correct settings ', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         settings: {
           mySettings: 'hello',
@@ -451,7 +451,7 @@ describe('Test Meilisearch plugin configurations', () => {
   })
 
   test('Test all contentTypes pointing to the same custom index name', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         indexName: 'my_index',
       },

--- a/server/__tests__/content-types.test.js
+++ b/server/__tests__/content-types.test.js
@@ -1,9 +1,9 @@
 const createContentTypeService = require('../services/content-types')
 
-const { createFakeStrapi } = require('./utils/fakes')
+const { createStrapiMock } = require('../__mocks__/strapi')
 
-const fakeStrapi = createFakeStrapi({})
-global.strapi = fakeStrapi
+const strapiMock = createStrapiMock({})
+global.strapi = strapiMock
 
 describe('Tests content types', () => {
   beforeEach(async () => {
@@ -12,7 +12,7 @@ describe('Tests content types', () => {
   })
 
   test('Test all api names of an empty content type', async () => {
-    const customStrapi = createFakeStrapi({ contentTypes: [] })
+    const customStrapi = createStrapiMock({ contentTypes: [] })
     const contentTypeServices = createContentTypeService({
       strapi: customStrapi,
     })
@@ -23,7 +23,7 @@ describe('Tests content types', () => {
   })
 
   test('Test all content types', async () => {
-    const contentTypeServices = createContentTypeService({ strapi: fakeStrapi })
+    const contentTypeServices = createContentTypeService({ strapi: strapiMock })
     const contentTypes = contentTypeServices.getContentTypesUid()
 
     expect(contentTypes.sort()).toEqual(
@@ -37,7 +37,7 @@ describe('Tests content types', () => {
   })
 
   test('Test names of empty content types', async () => {
-    const customStrapi = createFakeStrapi({ contentTypes: [] })
+    const customStrapi = createStrapiMock({ contentTypes: [] })
     const contentTypeServices = createContentTypeService({
       strapi: customStrapi,
     })
@@ -48,7 +48,7 @@ describe('Tests content types', () => {
   })
 
   test('Test empty content types', async () => {
-    const customStrapi = createFakeStrapi({ contentTypes: [] })
+    const customStrapi = createStrapiMock({ contentTypes: [] })
     const contentTypeServices = createContentTypeService({
       strapi: customStrapi,
     })
@@ -60,7 +60,7 @@ describe('Tests content types', () => {
 
   test('Test if content type exists', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const exists = contentTypeServices.getContentTypeUid({
@@ -72,7 +72,7 @@ describe('Tests content types', () => {
 
   test('Test number of entries', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const count = await contentTypeServices.numberOfEntries({
@@ -84,7 +84,7 @@ describe('Tests content types', () => {
 
   test('Test total number of entries', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const count = await contentTypeServices.totalNumberOfEntries({
@@ -100,14 +100,14 @@ describe('Tests content types', () => {
 
   test('Test fetching entries of a content type with default parameters', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const count = await contentTypeServices.getEntries({
       contentType: 'api::restaurant.restaurant',
     })
 
-    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledWith(
+    expect(strapiMock.entityService.findMany).toHaveBeenCalledWith(
       'api::restaurant.restaurant',
       {
         fields: '*',
@@ -119,13 +119,13 @@ describe('Tests content types', () => {
         publicationState: 'live',
       }
     )
-    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(1)
+    expect(strapiMock.entityService.findMany).toHaveBeenCalledTimes(1)
     expect(count).toEqual([{ id: 1 }])
   })
 
   test('Test fetching entries of a content type with custom parameters', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const count = await contentTypeServices.getEntries({
@@ -139,7 +139,7 @@ describe('Tests content types', () => {
       publicationState: 'preview',
     })
 
-    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledWith(
+    expect(strapiMock.entityService.findMany).toHaveBeenCalledWith(
       'api::restaurant.restaurant',
       {
         fields: 'title',
@@ -151,26 +151,26 @@ describe('Tests content types', () => {
         publicationState: 'preview',
       }
     )
-    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(1)
+    expect(strapiMock.entityService.findMany).toHaveBeenCalledTimes(1)
     expect(count).toEqual([{ id: 1 }])
   })
 
   test('Test fetching entries on non existing content type', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const entry = await contentTypeServices.getEntries({
       contentType: 'api::test.test',
     })
 
-    expect(fakeStrapi.entityService.findMany).toHaveBeenCalledTimes(0)
+    expect(strapiMock.entityService.findMany).toHaveBeenCalledTimes(0)
     expect(entry).toEqual([])
   })
 
   test('Test fetching an entry of a content type with default parameters', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const entry = await contentTypeServices.getEntry({
@@ -178,7 +178,7 @@ describe('Tests content types', () => {
       id: 200,
     })
 
-    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledWith(
+    expect(strapiMock.entityService.findOne).toHaveBeenCalledWith(
       'api::restaurant.restaurant',
       200,
       {
@@ -186,13 +186,13 @@ describe('Tests content types', () => {
         populate: '*',
       }
     )
-    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(1)
+    expect(strapiMock.entityService.findOne).toHaveBeenCalledTimes(1)
     expect(entry).toEqual([{ id: 1 }])
   })
 
   test('Test fetching an entry of a content type with custom parameters', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const entry = await contentTypeServices.getEntry({
@@ -206,7 +206,7 @@ describe('Tests content types', () => {
       },
     })
 
-    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledWith(
+    expect(strapiMock.entityService.findOne).toHaveBeenCalledWith(
       'api::restaurant.restaurant',
       200,
       {
@@ -216,26 +216,26 @@ describe('Tests content types', () => {
         },
       }
     )
-    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(1)
+    expect(strapiMock.entityService.findOne).toHaveBeenCalledTimes(1)
     expect(entry).toEqual([{ id: 1 }])
   })
 
   test('Test fetching an entry on a non existing content type', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const count = await contentTypeServices.getEntry({
       contentType: 'api::test.test',
     })
 
-    expect(fakeStrapi.entityService.findOne).toHaveBeenCalledTimes(0)
+    expect(strapiMock.entityService.findOne).toHaveBeenCalledTimes(0)
     expect(count).toEqual({})
   })
 
   test('Test operation in batches on entries', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const contentType = 'api::restaurant.restaurant'
@@ -254,7 +254,7 @@ describe('Tests content types', () => {
 
   test('Test operation in batches on entries with callback returning nothing', async () => {
     const contentTypeServices = createContentTypeService({
-      strapi: fakeStrapi,
+      strapi: strapiMock,
     })
 
     const contentType = 'api::restaurant.restaurant'

--- a/server/__tests__/meilisearch.test.js
+++ b/server/__tests__/meilisearch.test.js
@@ -1,14 +1,14 @@
 const createMeilisearchService = require('../services/meilisearch')
 
 const { MeiliSearch: Meilisearch } = require('meilisearch')
-const { createFakeStrapi } = require('./utils/fakes')
+const { createStrapiMock } = require('../__mocks__/strapi')
 
 jest.mock('meilisearch')
 
-const fakeStrapi = createFakeStrapi({})
+const strapiMock = createStrapiMock({})
 
 // @ts-ignore
-global.strapi = fakeStrapi
+global.strapi = strapiMock
 
 describe('Tests content types', () => {
   beforeEach(async () => {
@@ -17,7 +17,7 @@ describe('Tests content types', () => {
   })
 
   test('Test get all contentTypes types', async () => {
-    const customStrapi = createFakeStrapi({})
+    const customStrapi = createStrapiMock({})
 
     const meilisearchService = createMeilisearchService({
       strapi: customStrapi,
@@ -29,7 +29,7 @@ describe('Tests content types', () => {
   })
 
   test('Test to delete entries from Meilisearch', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         indexName: 'customIndex',
       },
@@ -56,7 +56,7 @@ describe('Tests content types', () => {
   })
 
   test('Test to get stats', async () => {
-    const customStrapi = createFakeStrapi({})
+    const customStrapi = createStrapiMock({})
 
     const meilisearchService = createMeilisearchService({
       strapi: customStrapi,
@@ -73,7 +73,7 @@ describe('Tests content types', () => {
   })
 
   test('Test to update the content of a collection in Meilisearch', async () => {
-    const customStrapi = createFakeStrapi({
+    const customStrapi = createStrapiMock({
       restaurantConfig: {
         entriesQuery: {
           limit: 1,


### PR DESCRIPTION
Mocking variables were called `fake`, they should be called `mock` as per convention.