### PR TITLE
Make plugin v3 version compatible with latest version of Meilisearch (v0.29.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Complete installation requirements are the same as for Strapi itself and can be 
 
 **Supported Meilisearch versions**:
 
-This package only guarantees the compatibility with the [version v0.29.1 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.26.0).
+This package only guarantees the compatibility with the [version v0.29.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0).
 
 **Node / NPM versions**:
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Complete installation requirements are the same as for Strapi itself and can be 
 
 **Supported Meilisearch versions**:
 
-This package only guarantees the compatibility with the [version v0.26.0 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.26.0).
+This package only guarantees the compatibility with the [version v0.29.1 of Meilisearch](https://github.com/meilisearch/meilisearch/releases/tag/v0.26.0).
 
 **Node / NPM versions**:
 

--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -21,91 +21,17 @@ import { headers } from '../utils/collection-header'
  */
 const Collections = ({ updateCredentials }) => {
   const [collectionsList, setCollectionsList] = useState([]) // All Collections
-  const [upToDateCollections, setUpToDateCollection] = useState(false) // Boolean that informs if collections have been updated.
   const [needReload, setNeedReload] = useState(false) // Boolean to inform that reload is requested.
-  const [collectionInWaitMode, setCollectionInWaitMode] = useState([]) // Collections that are waiting for their indexation to complete.
-  const [collectionTaskUids, setCollectionTaskUids] = useState({}) // List of collection's enqueued task uids.
+  const [realTimeReports, setRealTimeReports] = useState(false) // List of collection's enqueued task uids.
+  const [refetchIndex, setRefetchIndex] = useState(true)
 
-  // Trigger a task uids fetcher to find enqueued task of the indexed collections.
-  useEffect(() => {
-    findTaskUids()
-  }, [])
+  const refetchCollection = () =>
+    setRefetchIndex(prevRefetchIndex => !prevRefetchIndex)
 
   // Adds a listener that informs if collections have been updated.
   useEffect(() => {
-    setUpToDateCollection(false)
+    refetchCollection()
   }, [updateCredentials])
-
-  // Adds a listener that updates collections informations on updates
-  useEffect(() => {
-    if (!upToDateCollections) fetchCollections()
-  }, [upToDateCollections, updateCredentials])
-
-  // Trigger a watch if a collection has enqueued task uid's.
-  useEffect(() => {
-    for (const collection in collectionTaskUids) {
-      if (collectionTaskUids[collection].length > 0) {
-        watchTasks({ collection })
-      }
-    }
-  }, [collectionTaskUids])
-
-  /**
-   * Find all enqueued task uid's of the indexed collections.
-   * It is triggered on load.
-   */
-  const findTaskUids = async () => {
-    const response = await request(`/${pluginId}/collection/tasks`, {
-      method: 'GET',
-    })
-
-    if (response.error) errorNotifications(response)
-    setCollectionTaskUids(response.taskUids)
-  }
-
-  /**
-   * Watches a collection (if not already)
-   * For a maximum of 5 enqueued tasks in Meilisearch.
-   *
-   * @param {string} collection - Collection name.
-   */
-  const watchTasks = async ({ collection }) => {
-    // If collection has pending tasks
-    const taskUids = collectionTaskUids[collection]
-
-    if (!collectionInWaitMode.includes(collection) && taskUids?.length > 0) {
-      addIndexedStatus
-      setCollectionInWaitMode(prev => [...prev, collection])
-
-      const taskUidsIdsChunk = taskUids.splice(0, 1)
-      const response = await request(
-        `/${pluginId}/collection/${collection}/tasks/batch`,
-        {
-          method: 'POST',
-          body: { taskUids: taskUidsIdsChunk },
-        }
-      )
-
-      if (response.error) errorNotifications(response)
-
-      const { tasksStatus } = response
-
-      tasksStatus.map(task => {
-        if (task.status === 'failed') {
-          task.error.message = `Some documents could not be added: \n${task.error.message}`
-          errorNotifications(task.error)
-        }
-      })
-
-      setCollectionInWaitMode(prev => prev.filter(col => col !== collection))
-      setCollectionTaskUids(prev => ({
-        ...prev,
-        [collection]: taskUids,
-      }))
-
-      setUpToDateCollection(false) // Ask for collections to be updated.
-    }
-  }
 
   /**
    * Add a collection to Meilisearch
@@ -122,14 +48,7 @@ const Collections = ({ updateCredentials }) => {
 
     createResponseNotification(response, `${collection} is created!`)
 
-    if (!response.error) {
-      setCollectionTaskUids(prev => ({
-        ...prev,
-        [collection]: response.taskUids,
-      }))
-    }
-
-    setUpToDateCollection(false) // Ask for collections to be updated.
+    refetchCollection()
   }
 
   /**
@@ -147,14 +66,7 @@ const Collections = ({ updateCredentials }) => {
 
     createResponseNotification(response, `${collection} update started!`)
 
-    if (!response.error) {
-      setCollectionTaskUids(prev => ({
-        ...prev,
-        [collection]: response.taskUids,
-      }))
-    }
-
-    setUpToDateCollection(false) // Ask for collections to be updated.
+    refetchCollection()
   }
 
   /**
@@ -172,7 +84,7 @@ const Collections = ({ updateCredentials }) => {
       `${collection} collection is removed from Meilisearch!`
     )
 
-    setUpToDateCollection(false) // Ask for collections to be updated.
+    refetchCollection()
   }
 
   /**
@@ -200,12 +112,9 @@ const Collections = ({ updateCredentials }) => {
 
     if (error) errorNotifications(res)
     else {
-      // Start watching collections that have pending tasks
-      collections.map(col => {
-        if (col.isIndexing) {
-          watchTasks({ collection: col.collection })
-        }
-      })
+      const isIndexing = collections.find(col => col.isIndexing === true)
+
+      setRealTimeReports(isIndexing)
 
       // Transform collections information to verbose string.
       const renderedCols = collections.map(col => transformCollections(col))
@@ -217,9 +126,25 @@ const Collections = ({ updateCredentials }) => {
 
       setNeedReload(reloading) // A reload is required for a collection to be listened or de-listened
       setCollectionsList(renderedCols) // Store all `Strapi collections
-      setUpToDateCollection(true) // Collection information is up to date
     }
   }
+
+  // Start refreshing the collections when a collection is being indexed
+  useEffect(() => {
+    let interval
+    if (realTimeReports) {
+      interval = setInterval(() => {
+        refetchCollection()
+      }, 1000)
+    } else {
+      clearInterval(interval)
+    }
+    return () => clearInterval(interval)
+  }, [realTimeReports])
+
+  useEffect(() => {
+    fetchCollections()
+  }, [refetchIndex])
 
   return (
     <div className="col-md-12">

--- a/config/routes.json
+++ b/config/routes.json
@@ -34,22 +34,6 @@
     },
     {
       "method": "POST",
-      "path": "/collection/:collection/tasks/batch",
-      "handler": "meilisearch.waitForTasks",
-      "config": {
-        "policies": ["isAdmin"]
-      }
-    },
-    {
-      "method": "GET",
-      "path": "/collection/tasks",
-      "handler": "meilisearch.getTaskUids",
-      "config": {
-        "policies": ["isAdmin"]
-      }
-    },
-    {
-      "method": "POST",
       "path": "/collections/:collection",
       "handler": "meilisearch.addCollection",
       "config": {

--- a/connectors/meilisearch/index.js
+++ b/connectors/meilisearch/index.js
@@ -117,7 +117,8 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     getIndexes: async function () {
       try {
         const client = MeiliSearch({ apiKey, host })
-        return await client.getIndexes()
+        const { results } = await client.getIndexes()
+        return results
       } catch (e) {
         console.error(e)
         return []

--- a/connectors/meilisearch/index.js
+++ b/connectors/meilisearch/index.js
@@ -117,8 +117,7 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     getIndexes: async function () {
       try {
         const client = MeiliSearch({ apiKey, host })
-        const indexes = await client.getIndexes()
-        return indexes.results || []
+        return await client.getIndexes()
       } catch (e) {
         console.error(e)
         return []
@@ -385,6 +384,7 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     getCollectionsIndexedInMeiliSearch: async function (collections) {
       const indexes = await this.getIndexes()
       const indexUids = indexes.map(index => index.uid)
+
       return collections.filter(collection =>
         indexUids.includes(collectionConnector.getIndexName(collection))
       )

--- a/connectors/meilisearch/index.js
+++ b/connectors/meilisearch/index.js
@@ -67,49 +67,6 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     },
 
     /**
-     * Wait for an task to be processed in Meilisearch.
-     *
-     * @param  {string} collection - Collection name.
-     * @param  {number} taskUid - Task identifier.
-     *
-     * @returns {{Record<string, string>}} - Task body returned by Meilisearch API.
-     */
-    waitForTask: async function ({ collection, taskUid }) {
-      try {
-        const client = MeiliSearch({ apiKey, host })
-        const indexUid = collectionConnector.getIndexName(collection)
-        const task = await client
-          .index(indexUid)
-          .waitForTask(taskUid, { intervalMs: 5000 })
-
-        return task
-      } catch (e) {
-        console.error(e)
-        return 0
-      }
-    },
-
-    /**
-     * Wait for a batch of tasks uids to be processed.
-     *
-     * @param  {string} collection - Collection name.
-     * @param  {number[]} taskUids - Array of tasks identifiers.
-     *
-     * @returns { Record<string, string>[] } - List of all tasks returned by Meilisearch API.
-     */
-    waitForTasks: async function ({ collection, taskUids }) {
-      const tasks = []
-      for (const taskUid of taskUids) {
-        const status = await this.waitForTask({
-          collection,
-          taskUid,
-        })
-        tasks.push(status)
-      }
-      return tasks
-    },
-
-    /**
      * Get indexes with a safe guard in case of error.
      *
      * @returns { Promise<Record<string, any>[]> }
@@ -117,6 +74,7 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     getIndexes: async function () {
       try {
         const client = MeiliSearch({ apiKey, host })
+
         const { results } = await client.getIndexes()
         return results
       } catch (e) {
@@ -139,32 +97,6 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
       } catch (e) {
         return {}
       }
-    },
-
-    /**
-     * Get enqueued tasks ids of indexed collections.
-     *
-     * @returns { { string: number[] } } - Collections with their respective task uids
-     */
-    getTaskUids: async function () {
-      const indexes = await this.getIndexes()
-      const indexUids = indexes.map(index => index.uid)
-      const collections = collectionConnector.allEligbleCollections()
-      const client = MeiliSearch({ apiKey, host })
-
-      const collectionTaskUids = {}
-      for (const collection of collections) {
-        const indexUid = collectionConnector.getIndexName(collection)
-        if (indexUids.includes(indexUid)) {
-          const { results: tasks } = await client.index(indexUid).getTasks()
-
-          const enqueueded = tasks
-            .filter(task => task.status === 'enqueued')
-            .map(task => task.uid)
-          collectionTaskUids[collection] = enqueueded
-        }
-      }
-      return collectionTaskUids
     },
 
     /**

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -130,37 +130,9 @@ async function addCollection(ctx) {
   const connector = await createConnector()
   const { collection } = ctx.params
   const taskUids = await connector.addCollectionInMeiliSearch(collection)
+  console.log({ taskUids })
+
   return { message: 'Index created', taskUids }
-}
-
-/**
- * Wait for one collection to be completely indexed in Meilisearch.
- *
- * @param  {object} ctx - Http request object.
- *
- * @returns { numberOfDocumentsIndexed: number }
- */
-async function waitForTasks(ctx) {
-  const connector = await createConnector()
-  const { collection } = ctx.params
-  const { taskUids } = ctx.request.body
-  const tasksStatus = await connector.waitForTasks({
-    taskUids,
-    collection,
-  })
-  return { tasksStatus }
-}
-
-/**
- * Wait for one collection to be completely indexed in Meilisearch.
- *
- * @returns { taskUids: number[] }
- */
-async function getTaskUids() {
-  const connector = await createConnector()
-  const taskUids = await connector.getTaskUids()
-
-  return { taskUids }
 }
 
 /**
@@ -180,7 +152,5 @@ module.exports = {
   addCredentials: async ctx => ctxWrapper(ctx, addCredentials),
   removeCollection: async ctx => ctxWrapper(ctx, removeCollection),
   updateCollections: async ctx => ctxWrapper(ctx, updateCollections),
-  waitForTasks: async ctx => ctxWrapper(ctx, waitForTasks),
-  getTaskUids: async ctx => ctxWrapper(ctx, getTaskUids),
   reload: async ctx => ctxWrapper(ctx, reload),
 }

--- a/cypress/integration/ui_spec.js
+++ b/cypress/integration/ui_spec.js
@@ -13,8 +13,8 @@ const removeCollectionsFromMeiliSearch = async () => {
   const client = new MeiliSearch({ apiKey, host })
   const collections = ['restaurant', 'category', 'project', 'reviews']
   const { results } = await client.getIndexes()
-  const indexes = results || []
-  const allUids = indexes.map(index => index.uid)
+
+  const allUids = results.map(index => index.uid)
   const collectionInMs = collections.filter(col => allUids.includes(col))
   for (const index of collectionInMs) {
     await client.deleteIndex(index)

--- a/cypress/integration/ui_spec.js
+++ b/cypress/integration/ui_spec.js
@@ -12,7 +12,8 @@ const wrongApiKey = 'wrongApiKey'
 const removeCollectionsFromMeiliSearch = async () => {
   const client = new MeiliSearch({ apiKey, host })
   const collections = ['restaurant', 'category', 'project', 'reviews']
-  const indexes = await client.getIndexes()
+  const { results } = await client.getIndexes()
+  const indexes = results || []
   const allUids = indexes.map(index => index.uid)
   const collectionInMs = collections.filter(col => allUids.includes(col))
   for (const index of collectionInMs) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@buffetjs/core": "^3.3.8",
-    "meilisearch": "0.24.0"
+    "meilisearch": "^0.28.0"
   },
   "author": {
     "name": "Charlotte Vermandel <charlotte@meilisearch.com>"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,10 +3657,10 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-meilisearch@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.25.0.tgz#8e980fbdd36b9fe6ed606205e262418f21e64d84"
-  integrity sha512-TSIJTh5lva7WHBaoG3arNYQXuIAQkcD3BY09h2nHhjHS/wzxWKJM45x5bEC67Grw8zXihVqqmWty4a4ps4S+tg==
+meilisearch@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.28.0.tgz#650f08a56ef0a989a41d13233f7a744cfa7f54df"
+  integrity sha512-zC50xLyPWBtfAIZiFTSJyYJp/a5bO+dSSigBKUEoShFkuv9+/KC4J3T3ZejNVHXG2DU0ohOMf8TZ3HAHXNd3EA==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
⚠️ Failing tests are fixed in this PR #543 

This plugin hold both the version compatible with Strapi v4 `strapi-plugin-meilisearch@latest` and Strapi v3 `strapi-plugin-meilisearch@strapi_v3`.

Until this PR, the strapi v3 plugin as not compatible with the latest version of Meilisearch. This is now the case! 

Fixes: #444 