### PR TITLE
Simplify task fetching to avoid timeout in strapi v3

### DIFF
--- a/admin/src/components/Collections.js
+++ b/admin/src/components/Collections.js
@@ -114,8 +114,7 @@ const Collections = ({ updateCredentials }) => {
     else {
       const isIndexing = collections.find(col => col.isIndexing === true)
 
-      if (!isIndexing) setRealTimeReports(false)
-      else setRealTimeReports(true)
+      setRealTimeReports(isIndexing)
 
       // Transform collections information to verbose string.
       const renderedCols = collections.map(col => transformCollections(col))

--- a/config/routes.json
+++ b/config/routes.json
@@ -34,22 +34,6 @@
     },
     {
       "method": "POST",
-      "path": "/collection/:collection/tasks/batch",
-      "handler": "meilisearch.waitForTasks",
-      "config": {
-        "policies": ["isAdmin"]
-      }
-    },
-    {
-      "method": "GET",
-      "path": "/collection/tasks",
-      "handler": "meilisearch.getTaskUids",
-      "config": {
-        "policies": ["isAdmin"]
-      }
-    },
-    {
-      "method": "POST",
       "path": "/collections/:collection",
       "handler": "meilisearch.addCollection",
       "config": {

--- a/connectors/meilisearch/index.js
+++ b/connectors/meilisearch/index.js
@@ -74,7 +74,11 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     getIndexes: async function () {
       try {
         const client = MeiliSearch({ apiKey, host })
+        const version = await client.getVersion()
+        console.log({ version })
+
         const indexes = await client.getIndexes()
+        console.log({ indexes })
         return indexes.results || []
       } catch (e) {
         console.error(e)

--- a/connectors/meilisearch/index.js
+++ b/connectors/meilisearch/index.js
@@ -67,30 +67,6 @@ module.exports = async ({ storeConnector, collectionConnector }) => {
     },
 
     /**
-     * Wait for an task to be processed in Meilisearch.
-     *
-     * @param  {string} collection - Collection name.
-     * @param  {number} taskUid - Task identifier.
-     *
-     * @returns {{Record<string, string>}} - Task body returned by Meilisearch API.
-     */
-    waitForTask: async function ({ collection, taskUid }) {
-      try {
-        console.log({ collection, taskUid })
-
-        const client = MeiliSearch({ apiKey, host })
-        const indexUid = collectionConnector.getIndexName(collection)
-        const task = await client
-          .index(indexUid)
-          .waitForTask(taskUid, { intervalMs: 5000 })
-
-        return task
-      } catch (e) {
-        console.error(e)
-        return 0
-      }
-    },
-    /**
      * Get indexes with a safe guard in case of error.
      *
      * @returns { Promise<Record<string, any>[]> }

--- a/controllers/meilisearch.js
+++ b/controllers/meilisearch.js
@@ -130,37 +130,9 @@ async function addCollection(ctx) {
   const connector = await createConnector()
   const { collection } = ctx.params
   const taskUids = await connector.addCollectionInMeiliSearch(collection)
+  console.log({ taskUids })
+
   return { message: 'Index created', taskUids }
-}
-
-/**
- * Wait for one collection to be completely indexed in Meilisearch.
- *
- * @param  {object} ctx - Http request object.
- *
- * @returns { numberOfDocumentsIndexed: number }
- */
-async function waitForTasks(ctx) {
-  const connector = await createConnector()
-  const { collection } = ctx.params
-  const { taskUids } = ctx.request.body
-  const tasksStatus = await connector.waitForTasks({
-    taskUids,
-    collection,
-  })
-  return { tasksStatus }
-}
-
-/**
- * Wait for one collection to be completely indexed in Meilisearch.
- *
- * @returns { taskUids: number[] }
- */
-async function getTaskUids() {
-  const connector = await createConnector()
-  const taskUids = await connector.getTaskUids()
-
-  return { taskUids }
 }
 
 /**
@@ -180,7 +152,5 @@ module.exports = {
   addCredentials: async ctx => ctxWrapper(ctx, addCredentials),
   removeCollection: async ctx => ctxWrapper(ctx, removeCollection),
   updateCollections: async ctx => ctxWrapper(ctx, updateCollections),
-  waitForTasks: async ctx => ctxWrapper(ctx, waitForTasks),
-  getTaskUids: async ctx => ctxWrapper(ctx, getTaskUids),
   reload: async ctx => ctxWrapper(ctx, reload),
 }


### PR DESCRIPTION
Tests in cypress were failing because of a weird tasks listener. 

I simplified it by removing the complex system to listen to tasks and replacing it with a setInterval running until no tasks are left enqueued or processing.



