### PR TITLE
Update outdated docker run commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Each PR should pass the tests and the linter to be accepted.
 ```bash
 # Run a Meilisearch instance
 docker pull getmeili/meilisearch:latest # Fetch the latest version of Meilisearch image from Docker Hub
-docker run -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey --no-analytics
+docker run -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
 
 # Integration tests
 yarn test

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For example, if you use Docker:
 
 ```bash
 docker pull getmeili/meilisearch:latest # Fetch the latest version of Meilisearch image from Docker Hub
-docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --master-key=masterKey
+docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey
 ```
 
 ### 🏃‍♂️ Run Strapi <!-- omit in toc -->

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - meilisearch
   meilisearch:
     image: getmeili/meilisearch
-    command: ./meilisearch
+    command: meilisearch
     volumes:
       - ../meilisearch/data.ms:/data.ms
     ports:

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -8,7 +8,6 @@ services:
       - meilisearch
   meilisearch:
     image: getmeili/meilisearch
-    command: meilisearch
     volumes:
       - ../meilisearch/data.ms:/data.ms
     ports:


### PR DESCRIPTION
Docker commands where still using the old way to run the Meilisearch image. This is updated to the new way that is not running the binary  like this `./meilisearch` but like this `meilisearch`