### PR TITLE
Add support information for strapi v3 compatible plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ yarn playground:dev
 
 This command will install required dependencies and launch the app in development mode. You should be able to reach it on the [port 8000 of your localhost](http://localhost:8000/admin/).
 
-Once on the admin panel, you are required to log-in. Here are the credentials: 
+Once on the admin panel, you are required to log-in. Here are the credentials:
 - email: `jolene@doe.com`
 - password: `Qwertyuiop1`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/meilisearch_strapi.svg" alt="Meilisearch-Strapi" width="200" height="200" />
 </p>
 
-<h1 align="center">Meilisearch Strapi Plugin</h1>
+<h1 align="center">Meilisearch Strapi Plugin v3</h1>
 
 <h4 align="center">
   <a href="https://github.com/meilisearch/meilisearch">Meilisearch</a> |
@@ -440,7 +440,9 @@ Complete installation requirements are the same as for Strapi itself and can be 
 
 - Strapi `>=v3.6.x <v4.x.x`
 
-(This plugin **may work** with the older Strapi versions, but these are not tested nor officially supported at this time.)
+This plugin **may work** with the older Strapi versions, but these are not tested nor officially supported at this time.
+
+⚠️ We do not longer fix bugs on the v3 compatible plugin, unless critical. Nonetheless, we update it to work with the [latest version](https://github.com/meilisearch/meilisearch/releases) of Meilisearch.
 
 **Supported Meilisearch versions**:
 


### PR DESCRIPTION
Provide information on the fact that we:
- Do not fix bugs anymore on the strapi v3 plugin, unless critical
- Keep the plugin updated with the latest version of meilisearch