### PR TITLE
Update node versions used in CI to 14 when possible

### DIFF
--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Strapi is not yet compatible with node 16
-        node: ["12", "14"]
+        node: ['12', '14']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14"]
+        node: ['12', '14']
     name: playground-build (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: '14.x'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: '14.x'
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
@@ -110,7 +110,7 @@ jobs:
           chmod +x meilisearch
       - name: Run Meilisearch
         run: |
-          ./meilisearch --master-key=masterKey --no-analytics &
+          meilisearch --master-key=masterKey --no-analytics &
       - name: Install dependencies
         run: yarn --dev && yarn --cwd ./playground
       - name: Remove plugin symlink

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,16 +2,16 @@ name: publish to npm
 on:
   push:
     tags:
-      - v0.5.*
+      - v0.*.*-strapi-v3
 
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,16 @@ jobs:
     strategy:
       matrix:
         # Strapi is not yet compatible with node 16
-        node: ["12", "14"]
+        node: ['12', '14']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./node_modules
@@ -38,16 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14"]
+        node: ['12', '14']
     name: playground-build (Node.js ${{ matrix.node }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./node_modules
@@ -61,13 +61,13 @@ jobs:
     runs-on: ubuntu-latest
     name: style-check
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: '14.x'
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./node_modules
@@ -85,30 +85,25 @@ jobs:
     # Will still run for each push to bump-meilisearch-v*
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     runs-on: ubuntu-latest
-    container: cypress/browsers:node12.18.3-chrome87-ff82
+    container: cypress/browsers:node14.17.0-chrome88-ff89
     services:
       meilisearch:
         image: getmeili/meilisearch:latest
         env:
-          MEILI_MASTER_KEY: "masterKey"
-          MEILI_NO_ANALYTICS: "true"
+          MEILI_MASTER_KEY: 'masterKey'
+          MEILI_NO_ANALYTICS: 'true'
         ports:
-          - "7700:7700"
+          - '7700:7700'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ./node_modules
-          key: ${{ hashFiles('yarn.lock') }}
+        uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "12.x"
+          node-version: '14.x'
+          cache: yarn
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./playground/node_modules
@@ -130,18 +125,18 @@ jobs:
           mv config ./playground/plugins/meilisearch  &&
           mv services ./playground/plugins/meilisearch &&
           cp package.json ./playground/plugins/meilisearch
-      - name: Test with reloads activated
-        uses: cypress-io/github-action@v2
+      - name: Run e2e browser tests
+        uses: cypress-io/github-action@v3
         with:
           build: yarn playground:build
           start: yarn playground:ci
           env: env=ci
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-videos


### PR DESCRIPTION
Node 12 is EOF, we prefer using node 14 to run the environments. 
Nonetheless, we keep using node 12 in tests to ensure support of strapi v3 with node 12. 