### PR TITLE
Fix check release script replacing tr with cut

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Checking if current tag matches the package version
-current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/v')
+current_tag=$(echo $GITHUB_REF | cut -c 12-)
 file_tag=$(grep '"version":' package.json | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
 if [ "$current_tag" != "$file_tag" ]; then
   echo "Error: the current tag does not match the version in package file(s)."


### PR DESCRIPTION
The check-release script was using `tr`, tr removed every character provided as argument, thus in the script, the following: 
 `tr -d 'refs/tags/v'` removes every occurrence of the letters it contains. 
In our case, it removes `s, t, r, a`. resulting in `refs/tags/v0.1.0-strapi-v3.1` being transformed in `0.1.0-pi-v3.1`.

I updated the `check-release.sh` script using `cut` to remove these first 12 characters `refs/tags/v`.

