### PR TITLE
fix: issue causing TypeError: Cannot read properties of null (reading…

### DIFF
--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -215,7 +215,7 @@ module.exports = ({ strapi }) => {
       if (entriesQuery.publicationState === 'preview') {
         return entries
       } else {
-        return entries.filter(entry => !(entry.publishedAt === null))
+        return entries.filter(entry => !(entry?.publishedAt === null))
       }
     },
 


### PR DESCRIPTION
… 'publishedAt')

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- fix an issue in `server/services/meilisearch/config.js`

TypeError: Cannot read properties of null (reading 'publishedAt') at strapi-plugin-meilisearch/server/services/meilisearch/config.js:209:46

make change on this line
`return entries.filter(entry => !(entry?.publishedAt === null))`
to remove the error

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
