### PR TITLE
Create a custom _meilisearch_id field

### DIFF
--- a/resources/entries-query/populate.js
+++ b/resources/entries-query/populate.js
@@ -12,7 +12,8 @@ module.exports = {
 
 // The following document structure is indexed in Meilisearch
 // {
-//   id: 'restaurant-1',
+//   id: '1',
+//   _meilisearch_id: 'restaurant-1',
 //   title: 'The slimmy snail',
 //   // ... other restaurant fields
 //   repeatableComponent: [

--- a/server/services/meilisearch/adapter.js
+++ b/server/services/meilisearch/adapter.js
@@ -37,7 +37,7 @@ module.exports = ({ strapi }) => {
     addCollectionNamePrefix: function ({ contentType, entries }) {
       return entries.map(entry => ({
         ...entry,
-        id: this.addCollectionNamePrefixToId({
+        _meilisearch_id: this.addCollectionNamePrefixToId({
           entryId: entry.id,
           contentType,
         }),

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -130,7 +130,9 @@ module.exports = ({ strapi, adapter, config }) => {
             })
           )
         } else {
-          return client.index(indexUid).updateDocuments(sanitized)
+          return client
+            .index(indexUid)
+            .updateDocuments(sanitized, { primaryKey: '_meilisearch_id' })
         }
       })
     },
@@ -251,7 +253,9 @@ module.exports = ({ strapi, adapter, config }) => {
         adapter,
       })
 
-      const task = await client.index(indexUid).addDocuments(documents)
+      const task = await client
+        .index(indexUid)
+        .addDocuments(documents, { primaryKey: '_meilisearch_id' })
       await store.addIndexedContentType({ contentType })
 
       return task
@@ -285,7 +289,9 @@ module.exports = ({ strapi, adapter, config }) => {
         })
 
         // Add documents in Meilisearch
-        const task = await client.index(indexUid).addDocuments(documents)
+        const task = await client
+          .index(indexUid)
+          .addDocuments(documents, { primaryKey: '_meilisearch_id' })
 
         return task.taskUid
       }


### PR DESCRIPTION
#612

When indexing an entry to Meilisearch, the `id` field used to be transformed with a prepend of its collection name.

For example in a `restaurant` collection:

```json
{
   "id": 1,
   "name": "pizza mania"
}
```

Would become in Meilisearch:
```json
{
   "id": "restaurant-1",
   "name": "pizza mania"
}
```

With this PR, instead of overwriting the `id` field an additional field is added `_meilisearch_id`.

The entry in Meilisearch is thus transformed like this:
```json
{
   "id": 1,
    "name": "pizza mania",
    "_meilisearch_id": "restaurant-1"
}
```