### PR TITLE
Fix user-agent format

### DIFF
--- a/server/services/meilisearch/client.js
+++ b/server/services/meilisearch/client.js
@@ -12,5 +12,5 @@ const packageJson = require('../../../package.json')
 module.exports = config =>
   new Meilisearch({
     ...config,
-    clientAgents: [`Meilisearch Strapi ${packageJson.version}`],
+    clientAgents: [`Meilisearch Strapi (v${packageJson.version})`],
   })


### PR DESCRIPTION
The correct format should be: `Meilisearch Strapi (v1.2.3)` not `Meilisearch Strapi 1.2.3`