### PR TITLE
Add Strapi as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "@strapi/utils": "^4.10.5",
     "meilisearch": "^0.32.3"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+     "@strapi/strapi": "^4.0.0"
+  },
   "author": {
     "name": "Charlotte Vermandel <charlotte@meilisearch.com>"
   },


### PR DESCRIPTION
Ensures that the user uses this package with the version 4.x > of Strapi