### PR TITLE
Remove node 14 CI tests in favor of node 18

### DIFF
--- a/.github/workflows/beta-tests.yml
+++ b/.github/workflows/beta-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Strapi is not yet compatible with node 18
-        node: ['14', '16']
+        node: ['16', '18']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16']
+        node: ['16', '18']
     name: playground-build (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Strapi is not yet compatible with node 16
-        node: ['14', '16']
+        node: ['16', '18']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16']
+        node: ['16', '18']
     name: playground-build (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         # Strapi is not yet compatible with node 16
-        node: ['14', '16']
+        node: ['16', '18']
     name: integration-tests (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['14', '16']
+        node: ['16', '18']
     name: playground-build (Node.js ${{ matrix.node }})
     steps:
       - uses: actions/checkout@v3
@@ -72,7 +72,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,8 @@
 status = [
   'playground-build (Node.js 16)',
-  'playground-build (Node.js 14)',
+  'playground-build (Node.js 18)',
   'integration-tests (Node.js 16)',
-  'integration-tests (Node.js 14)',
+  'integration-tests (Node.js 18)',
   'style-check',
 ]
 # 1 hour timeout

--- a/playground/package.json
+++ b/playground/package.json
@@ -23,9 +23,5 @@
   "strapi": {
     "uuid": "227ce342-a655-4ff3-9374-17704b534984"
   },
-  "engines": {
-    "node": ">=12.x.x <=16.x.x",
-    "npm": ">=6.0.0"
-  },
   "license": "MIT"
 }


### PR DESCRIPTION
Strapi removed support for node 14, which makes our test on this node version irrelevant and not compatible with new versions of strapi packages.

See https://github.com/meilisearch/strapi-plugin-meilisearch/actions/runs/6045473041/job/16405570962?pr=801