### PR TITLE
fix: getIndexes limited to 20 indexes

### DIFF
--- a/server/__mocks__/meilisearch.js
+++ b/server/__mocks__/meilisearch.js
@@ -4,8 +4,23 @@ const updateSettingsMock = jest.fn(() => 10)
 const deleteDocuments = jest.fn(() => {
   return [{ taskUid: 1 }, { taskUid: 2 }]
 })
-const getIndexUids = jest.fn(() => {
-  return ['my_restaurant', 'restaurant']
+const getStats = jest.fn(() => {
+  return {
+    databaseSize: 447819776,
+    lastUpdate: '2019-11-15T11:15:22.092896Z',
+    indexes: {
+      my_restaurant: {
+        numberOfDocuments: 1,
+        isIndexing: false,
+        fieldDistribution: {},
+      },
+      restaurant: {
+        numberOfDocuments: 1,
+        isIndexing: false,
+        fieldDistribution: {},
+      },
+    },
+  }
 })
 
 const getTasks = jest.fn(() => {
@@ -18,7 +33,7 @@ const getTasks = jest.fn(() => {
   }
 })
 
-const getStats = jest.fn(() => {
+const getIndexStats = jest.fn(() => {
   return { numberOfDocuments: 1, isIndexing: false, fieldDistribution: {} }
 })
 
@@ -27,13 +42,13 @@ const mockIndex = jest.fn(() => ({
   updateDocuments: updateDocumentsMock,
   updateSettings: updateSettingsMock,
   deleteDocuments,
-  getStats,
+  getStats: getIndexStats,
 }))
 
 // @ts-ignore
 const mock = jest.fn().mockImplementation(() => {
   return {
-    getIndexUids,
+    getStats,
     index: mockIndex,
     getTasks,
   }

--- a/server/__mocks__/meilisearch.js
+++ b/server/__mocks__/meilisearch.js
@@ -4,8 +4,8 @@ const updateSettingsMock = jest.fn(() => 10)
 const deleteDocuments = jest.fn(() => {
   return [{ taskUid: 1 }, { taskUid: 2 }]
 })
-const getIndexes = jest.fn(() => {
-  return { results: [{ uid: 'my_restaurant' }, { uid: 'restaurant' }] }
+const getIndexUids = jest.fn(() => {
+  return ['my_restaurant', 'restaurant']
 })
 
 const getTasks = jest.fn(() => {
@@ -33,7 +33,7 @@ const mockIndex = jest.fn(() => ({
 // @ts-ignore
 const mock = jest.fn().mockImplementation(() => {
   return {
-    getIndexes,
+    getIndexUids,
     index: mockIndex,
     getTasks,
   }

--- a/server/__tests__/meilisearch.test.js
+++ b/server/__tests__/meilisearch.test.js
@@ -23,9 +23,9 @@ describe('Tests content types', () => {
       strapi: customStrapi,
     })
 
-    const indexes = await meilisearchService.getIndexes()
+    const indexes = await meilisearchService.getIndexUids()
 
-    expect(indexes).toEqual([{ uid: 'my_restaurant' }, { uid: 'restaurant' }])
+    expect(indexes).toEqual(['my_restaurant', 'restaurant'])
   })
 
   test('Test to delete entries from Meilisearch', async () => {

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -31,8 +31,7 @@ async function syncIndexedCollections({
   contentTypeService,
   meilisearch,
 }) {
-  const indexes = await meilisearch.getIndexes()
-  const indexUids = indexes.map(index => index.uid)
+  const indexUids = await meilisearch.getIndexUids()
   // All indexed contentTypes
   const indexedContentTypes = await store.getIndexedContentTypes()
   const contentTypes = contentTypeService.getContentTypesUid()

--- a/server/services/meilisearch/connector.js
+++ b/server/services/meilisearch/connector.js
@@ -65,16 +65,16 @@ module.exports = ({ strapi, adapter, config }) => {
 
   return {
     /**
-     * Get indexes with a safe guard in case of error.
+     * Get index uids with a safe guard in case of error.
      *
      * @returns { Promise<import("meilisearch").Index[]> }
      */
-    getIndexes: async function () {
+    getIndexUids: async function () {
       try {
         const { apiKey, host } = await store.getCredentials()
         const client = Meilisearch({ apiKey, host })
-        const { results: indexes } = await client.getIndexes()
-        return indexes
+        const { indexes } = await client.getStats()
+        return Object.keys(indexes)
       } catch (e) {
         strapi.log.error(`meilisearch: ${e.message}`)
         return []
@@ -176,8 +176,7 @@ module.exports = ({ strapi, adapter, config }) => {
      * }>}>} - List of contentTypes reports.
      */
     getContentTypesReport: async function () {
-      const indexes = await this.getIndexes()
-      const indexUids = indexes.map(index => index.uid)
+      const indexUids = await this.getIndexUids()
 
       // All listened contentTypes
       const listenedContentTypes = await store.getListenedContentTypes()


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes #714

## Context
Selecting more than 20 collections in the Meilisearch plugin causes issues where collections can't be selected or are reset in the Meilisearch plugin.

## What does this PR do?
The issue is that when retrieving the indexes through the `getIndexes` function, there is a limit set automatically by Meilisearch to `20` ([See reference](https://www.meilisearch.com/docs/reference/api/indexes#list-all-indexes)). As a result, only 20 indexes will be returned and the later checks between indexes in Meilisearch and collections in Strapi are wrong.

This PR changes the call to Meilisearch from GET `/indexes` to GET `/stats` which does not have a `limit`.

- Update `getIndexes` to `getIndexUids` and use the `getStats` function from `meilisearch-js`
  - Return an array containing all the `indexUids`
- Update tests

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
