### PR TITLE
Add id to getEntry return as fallback

### DIFF
--- a/server/services/content-types/content-types.js
+++ b/server/services/content-types/content-types.js
@@ -148,7 +148,7 @@ module.exports = ({ strapi }) => ({
       strapi.log.error(`Could not find entry with id ${id} in ${contentType}`)
     }
 
-    return entry || {}
+    return entry || { id }
   },
 
   /**


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #847 

## What does this PR do?
This modification allows us to later filterEntry if the entry is not found. 

The usecase for it is:
1. while using it with soft-delete plugin, the soft-delete first update and then delete it.
2. the way it is right now, filterEntry receives an empty object, so we can't trace what is this entry.
3. If we add the `id`, I believe there is no implication, and we can use it to build our logic at filterEntry, knowing at least the id.

This is our usecase, but I believe having the id can be useful in other scenarios that uses filterEntry, because at least you receive a relevant information at the filterEntry function.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
