### PR TITLE
Sanitize private fields selectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Settings:
 - [🤚 Filter entries](#-filter-entries)
 - [🏗 Add Meilisearch settings](#-add-meilisearch-settings)
 - [🔎 Entries query](#-entries-query)
+- [🔐 Selectively index private fields](#-selectively-index-private-fields)
 
 ### 🏷 Custom index name
 
@@ -411,6 +412,27 @@ module.exports = {
 ```
 
 [See resources](./resources/entries-query) for more entriesQuery examples.
+
+### 🔐 Selectively index private fields
+
+Private fields are sanitized by default to prevent data leaks. However, you might want to allow some of these private fields to be used for `search`, `filter` or `sort`. This is possible with the `noSanitizePrivateFields`. For example, if you have a private field called `internal_notes` in your content-type schema that you wish to include in searching, you can add it to the `noSanitizePrivateFields` array to allow it to be indexed.
+
+```js
+// config/plugins.js
+
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        noSanitizePrivateFields: ["internal_notes"], // All attributes: ["*"]
+        settings:  {
+          "searchableAttributes": ["internal_notes"],
+        }
+      },
+    },
+  },
+}
+```
 
 ### 🕵️‍♀️ Start Searching <!-- omit in toc -->
 

--- a/server/__tests__/configuration-validation.test.js
+++ b/server/__tests__/configuration-validation.test.js
@@ -245,6 +245,41 @@ describe('Test plugin configuration', () => {
     expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
   })
 
+  test('Test noSanitizePrivateFields with wrong type', async () => {
+    validatePluginConfig({
+      restaurant: {
+        noSanitizePrivateFields: 0,
+      },
+    })
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(1)
+    expect(strapiMock.log.error).toHaveBeenCalledWith(
+      'The "noSanitizePrivateFields" option of "restaurant" should be an array of strings.'
+    )
+  })
+
+  test('Test noSanitizePrivateFields with array of strings', async () => {
+    const configuration = validatePluginConfig({
+      restaurant: {
+        noSanitizePrivateFields: ['test'],
+      },
+    })
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
+    expect(configuration.restaurant.noSanitizePrivateFields).toEqual(['test'])
+  })
+
+  test('Test noSanitizePrivateFields with undefined', async () => {
+    validatePluginConfig({
+      restaurant: {
+        noSanitizePrivateFields: undefined,
+      },
+    })
+
+    expect(strapiMock.log.warn).toHaveBeenCalledTimes(0)
+    expect(strapiMock.log.error).toHaveBeenCalledTimes(0)
+  })
+
   test('Test configuration with random field ', async () => {
     validatePluginConfig({
       restaurant: {

--- a/server/configuration-validation.js
+++ b/server/configuration-validation.js
@@ -175,6 +175,7 @@ function CollectionConfig({ collectionName, configuration }) {
     filterEntry,
     settings,
     entriesQuery,
+    noSanitizePrivateFields,
     ...unknownFields
   } = configuration
   const options = {}
@@ -262,6 +263,21 @@ function CollectionConfig({ collectionName, configuration }) {
 
       return this
     },
+    validateNoSanitizePrivateFields() {
+      // noSanitizePrivateFields is either undefined or an array
+      if (
+        noSanitizePrivateFields !== undefined &&
+        !Array.isArray(noSanitizePrivateFields)
+      ) {
+        log.error(
+          `The "noSanitizePrivateFields" option of "${collectionName}" should be an array of strings.`
+        )
+      } else if (noSanitizePrivateFields !== undefined) {
+        options.noSanitizePrivateFields = noSanitizePrivateFields
+      }
+
+      return this
+    },
 
     validateNoInvalidKeys() {
       // Keys that should not be present in the configuration
@@ -323,8 +339,9 @@ function PluginConfig({ configuration }) {
             .validateFilterEntry()
             .validateTransformEntry()
             .validateMeilisearchSettings()
-            .validateNoInvalidKeys()
             .validateEntriesQuery()
+            .validateNoSanitizePrivateFields()
+            .validateNoInvalidKeys()
             .get()
         }
       }

--- a/server/services/meilisearch/config.js
+++ b/server/services/meilisearch/config.js
@@ -189,10 +189,22 @@ module.exports = ({ strapi }) => {
      * @return {Array<Object>} - Entries
      */
     removeSensitiveFields: function ({ contentType, entries }) {
+      const collection = contentTypeService.getCollectionName({ contentType })
+      const contentTypeConfig = meilisearchConfig[collection] || {}
+
+      const noSanitizePrivateFields =
+        contentTypeConfig.noSanitizePrivateFields || []
+
+      if (noSanitizePrivateFields.includes('*')) {
+        return entries
+      }
+
       // TODO: should be persisted somewhere to make it more performant
       const attrs = strapi.contentTypes[contentType].attributes
       const privateFields = Object.entries(attrs).map(([field, schema]) =>
-        schema.private ? field : false
+        schema.private && !noSanitizePrivateFields.includes(field)
+          ? field
+          : false
       )
 
       return entries.map(entry => {


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #773

## What does this PR do?
This allows user to selectively index private fields which are by default sanitized.

- Added a setting called `noSanitizePrivateFields` to the meilisearch config that allows user to define an array of private field names that need to be indexed.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
