### PR TITLE
docs(readme): specify i18n use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,8 @@ The options you can set are described in the [`findMany` documentation](https://
 
 If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` should also be added in `entriesQuery`.
 
-Warning : if you do not specify `locale: "all"` in `entriesQuery`, you may not index all available entries, potentially leading to missing products in your search results. To ensure all entries in every language are indexed in Meilisearch, include the `locale` field with the value 'all'.
+⚠️ Warning: if you do not specify `locale: "all"` in `entriesQuery`, you may not index all available entries, potentially leading to missing products in your search results. To ensure all entries in every language are indexed in Meilisearch, include the `locale` field with the value 'all'.
+
 ```js
 module.exports = {
   meilisearch: {

--- a/README.md
+++ b/README.md
@@ -425,7 +425,22 @@ The options you can set are described in the [`findMany` documentation](https://
 
 **Common use cases**
 
-If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` can also be added in `entriesQuery`.
+If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` should also be added in `entriesQuery`.
+
+Warning : if you do not specify `locale: "all"` in `entriesQuery`, you may not index all available entries, potentially leading to missing products in your search results. To ensure all entries in every language are indexed in Meilisearch, include the `locale` field with the value 'all'.
+```js
+module.exports = {
+  meilisearch: {
+    config: {
+      restaurant: {
+        entriesQuery: {
+          locale: 'all',
+        },
+      },
+    },
+  },
+}
+```
 
 If you want to add a collection with a relation to the collection being included, you have to configure the `populate` parameter in `entriesQuery`. See [the docs](https://docs.strapi.io/dev-docs/api/entity-service/populate) on how it works, and [an example](./resources/entries-query/populate.js) in our resources.
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR updates the documentation to highlight a critical configuration for indexing multilingual content in Strapi with Meilisearch. 
It adds a warning about specifying locale: 'all' in entriesQuery to ensure all language versions of content are indexed. 
This change is based on a bug I encountered due to unclear documentation, aiming to prevent similar issues for others.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
