### PR TITLE
Add support to Strapi v5 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Say goodbye to server deployment and manual updates with [Meilisearch Cloud](htt
 
 ## 🔧 Installation
 
-This package version works with the [v4 of Strapi](https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html). If you are using [Strapi v3](https://docs-v3.strapi.io/developer-docs/latest/getting-started/introduction.html), please refer to [this README](https://github.com/meilisearch/strapi-plugin-meilisearch/tree/v3_main).
+This package version works with the [v5 of Strapi](https://docs.strapi.io/dev-docs/intro). If you are using [Strapi v4](https://docs-v4.strapi.io/), refer to versions under [`v0.12`](https://github.com/meilisearch/strapi-plugin-meilisearch/tree/v0.12.0), if you are using [Strapi v3](https://docs-v3.strapi.io/), consider [this README](https://github.com/meilisearch/strapi-plugin-meilisearch/tree/v3_main).
 
 Inside your Strapi app, add the package:
 
@@ -75,7 +75,7 @@ To apply the plugin to Strapi, a re-build is needed:
 strapi build
 ```
 
-You will need both a running Strapi app and a running Meilisearch instance. For [specific version compatibility see this section](#-compatibility-with-meilisearch-and-strapi).
+You will need both a running Strapi app and a running Meilisearch instance. For [specific version compatibility, see this section](#-compatibility-with-meilisearch-and-strapi).
 
 ### 🏃‍♀️ Run Meilisearch <!-- omit in toc -->
 
@@ -112,7 +112,7 @@ yarn develop
 
 ### Run Both with Docker
 
-To run Meilisearch and Strapi on the same server you can use Docker. A Docker configuration example can be found in the directory [`resources/docker`](resources/docker/) of this repository.
+You can use Docker to run Meilisearch and Strapi on the same server. A Docker configuration example can be found in the directory [`resources/docker`](resources/docker/) of this repository.
 
 To run the Docker script add both files `Dockerfile` and `docker-compose.yaml` at the root of your Strapi project and run it with the following command: `docker-compose up`.
 
@@ -630,7 +630,7 @@ This command will install the required dependencies and launch the app in develo
 
 Complete installation requirements are the same as for Strapi itself and can be found in the documentation under [installation Requirements](https://strapi.io/documentation/v3.x/installation/cli.html#step-1-make-sure-requirements-are-met).
 
-- Strapi `>=v4.x.x`
+- Strapi `>=v5.x.x`
 
 If you are using [Strapi v3](https://github.com/strapi/strapi/tree/v3.6.9), please refer to [this README](https://github.com/meilisearch/strapi-plugin-meilisearch/tree/v0.5.1).
 


### PR DESCRIPTION
Just update the minimal items required to showcase that we are supporting Strapi v5 now.
