### PR TITLE
Add support for indexing with wildcard locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You will need both a running Strapi app and a running Meilisearch instance. For 
 
 ⚡️ **Launch, scale, and streamline in minutes with Meilisearch Cloud**—no maintenance, no commitment, cancel anytime. [Try it free now](https://cloud.meilisearch.com/login?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch).
 
-🪨  Prefer to self-host? [Download and deploy](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch) our fast, open-source search engine on your own infrastructure.
+🪨 Prefer to self-host? [Download and deploy](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch) our fast, open-source search engine on your own infrastructure.
 
 ### 🏃‍♂️ Run Strapi <!-- omit in toc -->
 
@@ -427,9 +427,9 @@ The options you can set are described in the [`findMany` documentation](https://
 
 **Common use cases**
 
-If you are using the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, an additional field `locale` should also be added in `entriesQuery`.
+If you are localizing your Strapi content, an additional field `locale` should also be added in `entriesQuery`.
 
-⚠️ Warning: if you do not specify `locale: "all"` in `entriesQuery`, you may not index all available entries, potentially leading to missing products in your search results. To ensure all entries in every language are indexed in Meilisearch, include the `locale` field with the value 'all'.
+⚠️ Warning: if you do not specify `locale: "*"` in `entriesQuery`, you may not index all available entries, potentially leading to missing products in your search results. To ensure all entries in every language are indexed in Meilisearch, include the `locale` field with the value 'all'.
 
 ```js
 module.exports = {
@@ -437,13 +437,15 @@ module.exports = {
     config: {
       restaurant: {
         entriesQuery: {
-          locale: 'all',
+          locale: '*',
         },
       },
     },
   },
 }
 ```
+
+If you are using Strapi 4 with the [🌍 Internationalization (i18n)](https://docs.strapi.io/developer-docs/latest/plugins/i18n.html) plugin, the `locale` field should be set to `all`.
 
 If you want to add a collection with a relation to the collection being included, you have to configure the `populate` parameter in `entriesQuery`. See [the docs](https://docs.strapi.io/dev-docs/api/entity-service/populate) on how it works, and [an example](./resources/entries-query/populate.js) in our resources.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You will need both a running Strapi app and a running Meilisearch instance. For 
 
 ⚡️ **Launch, scale, and streamline in minutes with Meilisearch Cloud**—no maintenance, no commitment, cancel anytime. [Try it free now](https://cloud.meilisearch.com/login?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch).
 
-🪨 Prefer to self-host? [Download and deploy](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch) our fast, open-source search engine on your own infrastructure.
+🪨  Prefer to self-host? [Download and deploy](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch?utm_campaign=oss&utm_source=github&utm_medium=strapi-plugin-meilisearch) our fast, open-source search engine on your own infrastructure.
 
 ### 🏃‍♂️ Run Strapi <!-- omit in toc -->
 

--- a/resources/entries-query/locale.js
+++ b/resources/entries-query/locale.js
@@ -4,7 +4,7 @@ module.exports = {
     config: {
       restaurant: {
         entriesQuery: {
-          locale: 'all',
+          locale: '*',
         },
       },
     },

--- a/server/src/__tests__/configuration.test.js
+++ b/server/src/__tests__/configuration.test.js
@@ -393,6 +393,34 @@ describe('Test Meilisearch plugin configurations', () => {
     expect(entries).toEqual([{ id: 1, locale: 'fr' }])
   })
 
+  test('Test should not remove any entries with wildcard locale', async () => {
+    const customStrapi = createStrapiMock({
+      restaurantConfig: {
+        entriesQuery: {
+          locale: '*',
+        },
+      },
+    })
+
+    const contentType = 'restaurant'
+    const meilisearchService = createMeilisearchService({
+      strapi: customStrapi,
+    })
+
+    const entries = meilisearchService.removeLocaleEntries({
+      contentType,
+      entries: [
+        { id: 1, locale: 'fr' },
+        { id: 2, locale: 'en' },
+      ],
+    })
+
+    expect(entries).toEqual([
+      { id: 1, locale: 'fr' },
+      { id: 2, locale: 'en' },
+    ])
+  })
+
   test('Test should keep unpublished entries when status is set to draft', async () => {
     const customStrapi = createStrapiMock({
       restaurantConfig: {

--- a/server/src/services/meilisearch/config.js
+++ b/server/src/services/meilisearch/config.js
@@ -243,8 +243,10 @@ export default ({ strapi }) => {
 
     /**
      * Remove language entries.
-     * In the plugin entriesQuery, if `locale` is set and not equal to `all`
-     * all entries that do not have the specified language are removed.
+     * In the plugin entriesQuery, if `locale` is set and not equal to
+     * `all` (used with the i18n plugin for Strapi) or `*` (used with Strapi 5
+     * native localization), all entries that do not have the specified
+     * language are removed.
      *
      * @param {object} options
      * @param {Array<Object>} options.entries - The entries to filter.
@@ -258,7 +260,11 @@ export default ({ strapi }) => {
 
       const entriesQuery = contentTypeConfig.entriesQuery || {}
 
-      if (!entriesQuery.locale || entriesQuery.locale === 'all') {
+      if (
+        !entriesQuery.locale ||
+        entriesQuery.locale === 'all' ||
+        entriesQuery.locale === '*'
+      ) {
         return entries
       } else {
         return entries.filter(entry => entry.locale === entriesQuery.locale)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #988 

## What does this PR do?
- Adds back support for indexing (all) localised content types in Strapi.
- Updates README and examples

The [i18n plugin](https://docs-v4.strapi.io/dev-docs/plugins/i18n) in Strapi 4 to localise content used the key-value pair `locale: 'all'` in the `entriesQuery` to query entries in all locales. [This is reflected in the `strapi-plugin-meilisearch` README](https://github.com/meilisearch/strapi-plugin-meilisearch?tab=readme-ov-file#-entries-query). 

[In Strapi 5, i18n is now part of the Strapi core](https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/i18n-content-manager-locale). With this change, the key-value pair changed to `locale: '*'`. 

(Or perhaps this change happened together with the move from the [Entity Service API](https://docs.strapi.io/dev-docs/api/entity-service/crud) to the [Document Service API](https://docs.strapi.io/dev-docs/api/document-service)). Reading the code, it appears that this plugin already uses the Document Service, but the [link in the `strapi-plugin-meilisearch` README still points to the Entity Service](https://github.com/meilisearch/strapi-plugin-meilisearch?tab=readme-ov-file#-entries-query). Regardless of whether the root cause is the Strapi 4 + i18n / Strapi 5 change, or the Entity Service / Document Service change, I've updated the README to point to the correct docs.)

This PR only _adds_ support for the wildcard `*` locale, and left support in for the `all` locale, used previously, maintaining backwards compatibility. I've updated the README to reflect usage first and foremost with Strapi 5, with a small note for usage with Strapi 4.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thanks for the work on the plugin, happy to hear your thoughts and make adjustments to the PR as needed!
