### PR TITLE
Use Meilisearch enterprise edition

### DIFF
--- a/.github/scripts/beta-docker-version.sh
+++ b/.github/scripts/beta-docker-version.sh
@@ -4,6 +4,6 @@ package_json_version=$(grep '"version":' package.json | cut -d ':' -f 2- | tr -d
 beta_feature=$(echo $package_json_version | sed -r 's/[0-9]+.[0-9]+.[0-9]+-//')
 beta_feature=$(echo $beta_feature | sed -r 's/-beta\.[0-9]*$//')
 
-docker_image=$(curl https://hub.docker.com/v2/repositories/getmeili/meilisearch/tags | jq | grep "$beta_feature" | head -1)
+docker_image=$(curl https://hub.docker.com/v2/repositories/getmeili/meilisearch-enterprise/tags | jq | grep "$beta_feature" | head -1)
 docker_image=$(echo $docker_image | grep '"name":' | cut -d ':' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
 echo $docker_image

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,12 +10,12 @@ jobs:
       options: --user 1001
     services:
       meilisearch:
-        image: getmeili/meilisearch:latest
+        image: getmeili/meilisearch-enterprise:latest
         env:
-          MEILI_MASTER_KEY: 'masterKey'
-          MEILI_NO_ANALYTICS: 'true'
+          MEILI_MASTER_KEY: "masterKey"
+          MEILI_NO_ANALYTICS: "true"
         ports:
-          - '7700:7700'
+          - "7700:7700"
 
     steps:
       - name: Checkout
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: "20.x"
           cache: yarn
       - name: Cache dependencies
         uses: actions/cache@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ Each PR should pass the tests and the linter to be accepted.
 
 ```bash
 # Run a Meilisearch instance
-docker pull getmeili/meilisearch:latest # Fetch the latest version of Meilisearch image from Docker Hub
-docker run -p 7700:7700 getmeili/meilisearch:latest meilisearch --master-key=masterKey --no-analytics
+docker pull getmeili/meilisearch-enterprise:latest # Fetch the latest version of Meilisearch image from Docker Hub
+docker run -p 7700:7700 getmeili/meilisearch-enterprise:latest meilisearch --master-key=masterKey --no-analytics
 
 # Integration tests
 yarn test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - "1337:1337"
 
   meilisearch:
-    image: getmeili/meilisearch:latest
+    image: getmeili/meilisearch-enterprise:latest
     ports:
       - "7700:7700"
     environment:

--- a/resources/docker/docker-compose.yaml
+++ b/resources/docker/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - meilisearch
   meilisearch:
-    image: getmeili/meilisearch
+    image: getmeili/meilisearch-enterprise
     command: meilisearch
     volumes:
       - ../meilisearch/data.ms:/data.ms


### PR DESCRIPTION
Starting from [Meilisearch v1.28](https://github.com/meilisearch/meilisearch/releases/tag/v1.28.0), the community and enterprise editions of Meilisearch have distinct binaries.

To allow full-feature coverage, this PR updates the repository to test against the enterprise edition instead of the default community edition by using the `getmeili/meilisearch-enterprise` Docker image.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service Docker image to enterprise edition across all deployment configurations and scripts.
  * Normalized string formatting in workflow configurations for consistency.

* **Documentation**
  * Updated contribution guidelines with enterprise Docker image references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->