### PR TITLE
Publish with provenance flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup-node-and-deps
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org/
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
       - name: Check tag format
@@ -26,7 +25,7 @@ jobs:
         run: yarn build
       - name: Publish with latest tag
         if: "!github.event.release.prerelease && !contains(github.ref, 'beta')"
-        run: npm publish .
+        run: npm publish . --access public --provenance
       - name: Publish with beta tag
         if: "github.event.release.prerelease && contains(github.ref, 'beta')"
-        run: npm publish . --tag beta
+        run: npm publish . --access public --provenance --tag beta


### PR DESCRIPTION
# Description

## Why

Fixes the publishing workflow following migration to OIDC

## How

- Update `publish.yml` with proper npm flags and workflow permissions

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide
- [ ] ⚠️⚠️ **I have run Cypress E2E tests locally** ⚠️⚠️

> [!warning]
> Cypress tests are currently flaky in CI. Until they are fixed, we require that you paste your local Cypress logs to encourage local testing.

**Output from `yarn cypress run`:**

```
# Paste cypress run output here
N/A
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow configuration and build setup.
  * Enhanced package publishing with explicit access controls and provenance verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->