### PR TITLE
Do not record Cypress run when record key is missing

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -58,7 +58,7 @@ jobs:
           start: yarn playground:dev
           env: env=ci
           browser: chrome
-          record: true
+          record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # Allows Cypress to detect new build vs re-run build


### PR DESCRIPTION
# Description

## Why

Fix #1097

## How

- Make `record` flag optional (false if variable is not set)

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide
- [x] ⚠️⚠️ **I have run Cypress E2E tests locally** ⚠️⚠️

> [!warning]
> Cypress tests are currently flaky in CI. Until they are fixed, we require that you paste your local Cypress logs to encourage local testing.

**Output from `yarn cypress run`:**

```
# Paste cypress run output here
N/A
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration test recording configuration to conditionally activate based on secret credential availability at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->