### PR TITLE
Update outdated documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://roadmap.meilisearch.com/tabs/1-under-consideration">Roadmap</a> |
   <a href="https://www.meilisearch.com">Website</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -41,7 +41,7 @@ Add your Strapi content-types into a Meilisearch instance. The plugin listens to
 
 ## 📖 Documentation
 
-To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://www.meilisearch.com/docs/learn/getting_started/installation).
+To understand Meilisearch and how it works, see the [Meilisearch's documentation](https://www.meilisearch.com/docs/learn/self_hosted/install_meilisearch_locally).
 
 To understand Strapi and how to create an app, see [Strapi's documentation](https://strapi.io/documentation/developer-docs/latest/getting-started/introduction.html).
 
@@ -117,9 +117,9 @@ First, you need to configure credentials via the Strapi config, or on the plugin
 The credentials are composed of:
 
 - The `host`: The url to your running Meilisearch instance.
-- The `api_key`: The `master` or `private` key as the plugin requires administration permission on Meilisearch.[More about permissions here](https://www.meilisearch.com/docs/reference/features/authentication.html).
+- The `api_key`: The `master` or `private` key as the plugin requires administration permission on Meilisearch.[More about permissions here](https://www.meilisearch.com/docs/reference/api/authorization).
 
-⚠️ The `master` or `private` key should never be used to `search` on your front end. For searching, use the `public` key available on [the `key` route](https://www.meilisearch.com/docs/reference/api/keys.html#get-keys).
+⚠️ The `master` or `private` key should never be used to `search` on your front end. For searching, use the `public` key available on [the `key` route](https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-keys).
 
 #### Using the plugin page
 
@@ -363,7 +363,7 @@ Result:
 }
 ```
 
-By transforming the `categories` into an array of names, it is now compatible with the [`filtering` feature](https://www.meilisearch.com/docs/reference/features/filtering_and_faceted_search.html#configuring-filters) in Meilisearch.
+By transforming the `categories` into an array of names, it is now compatible with the [`filtering` feature](https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results#configuring-filters) in Meilisearch.
 
 **Important**: You should always return the id of the entry without any transformation to [allow sync](https://github.com/meilisearch/strapi-plugin-meilisearch/issues/487) when unpublished or deleting some entries in Strapi.
 
@@ -394,7 +394,7 @@ module.exports = {
 
 ### 🏗 Add Meilisearch settings
 
-Each index in Meilisearch can be customized with specific settings. It is possible to add your [Meilisearch settings](https://www.meilisearch.com/docs/reference/api/settings#settings_parameters#settings) configuration to the indexes you create using the `settings` field in the plugin configuration file.
+Each index in Meilisearch can be customized with specific settings. It is possible to add your [Meilisearch settings](https://www.meilisearch.com/docs/reference/api/settings/list-all-settings#settings_parameters#settings) configuration to the indexes you create using the `settings` field in the plugin configuration file.
 
 The settings are added when either: adding a content-type to Meilisearch or when updating a content-type in Meilisearch. The settings are not updated when documents are added through the [`listeners`](-apply-hooks).
 
@@ -491,7 +491,7 @@ module.exports = {
 
 ### 🕵️‍♀️ Start Searching <!-- omit in toc -->
 
-Once you have a content-type indexed in Meilisearch, you can [start searching](https://www.meilisearch.com/docs/learn/getting_started/quick_start.html#search).
+Once you have a content-type indexed in Meilisearch, you can [start searching](https://www.meilisearch.com/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch#search).
 
 To search in Meilisearch, you can use the [instant-meilisearch](https://github.com/meilisearch/meilisearch-js-plugins/tree/main/packages/instant-meilisearch) library that integrates a whole search interface, or our [meilisearch-js](https://github.com/meilisearch/meilisearch-js) SDK.
 
@@ -644,7 +644,7 @@ If you want to know more about the development workflow or want to contribute, p
 ## 🌎 Community support
 
 - For general help using **Meilisearch**, please refer to [the official Meilisearch documentation](https://www.meilisearch.com/docs).
-- Contact the [Meilisearch support](https://www.meilisearch.com/docs/learn/what_is_meilisearch/contact.html)
+- Contact the [Meilisearch support](https://www.meilisearch.com/docs)
 - Strapi [community Slack](https://slack.strapi.io/)
 - For general help using **Strapi**, please refer to [the official Strapi documentation](https://strapi.io/documentation/).
 

--- a/admin/src/containers/Settings/Credentials.jsx
+++ b/admin/src/containers/Settings/Credentials.jsx
@@ -76,7 +76,7 @@ const Credentials = () => {
           )}{' '}
           <Link
             isExternal
-            href="https://www.meilisearch.com/docs/reference/api/keys#get-keys"
+            href="https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#get-keys"
           >
             <Typography variant="pi" style={{ color: 'red' }}>
               {i18n(

--- a/resources/meilisearch-settings/make-relationship-filterable.js
+++ b/resources/meilisearch-settings/make-relationship-filterable.js
@@ -4,7 +4,7 @@
  *
  * In Meilisearch you can use filters to for example in our case, only find italian restaurants.
  * To be able to do that, you need to provide a list of values and add in the settings the field in `filterableAttributes`.
- * See guide: https://www.meilisearch.com/docs/learn/advanced/filtering
+ * See guide: https://www.meilisearch.com/docs/learn/filtering_and_sorting/filter_search_results
  *
  * In Strapi, when fetching an entry the many-to-many relationships are inside an object:
  *


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs