### PR TITLE
Fix count of number of entries when using localization

### DIFF
--- a/cypress/e2e/features.cy.js
+++ b/cypress/e2e/features.cy.js
@@ -64,48 +64,6 @@ describe('Meilisearch features', () => {
   }
 
   /**
-   * Poll by refreshing the page until a collection shows the expected indexed state.
-   * This handles Meilisearch's eventual consistency.
-   * @param {string} collectionName - Collection name
-   * @param {string} expectedText - Expected text in the row ('Yes' or 'No')
-   * @param {number} maxAttempts - Max polling attempts
-   * @param {number} intervalMs - Interval between polls in ms
-   */
-  const pollUntilState = (
-    collectionName,
-    expectedText,
-    maxAttempts = 15,
-    intervalMs = 2000,
-  ) => {
-    const poll = attempt => {
-      if (attempt >= maxAttempts) {
-        throw new Error(
-          `Timed out waiting for "${collectionName}" to contain "${expectedText}"`,
-        )
-      }
-
-      // Use getRow helper and check the row text
-      return getRow(collectionName, { timeout: 10000 }).then($row => {
-        const rowText = $row.text()
-
-        // Check if row contains the expected text
-        if (rowText.includes(expectedText)) {
-          // Found expected state
-          return
-        }
-
-        // Not yet in expected state, wait then refresh
-        cy.wait(intervalMs)
-        cy.reload()
-        cy.contains('Collections', { timeout: 10000 }).should('be.visible')
-        return poll(attempt + 1)
-      })
-    }
-
-    return poll(0)
-  }
-
-  /**
    * Ensure a collection is indexed (checkbox checked).
    * Uses network intercepts to wait for backend sync.
    * @param {string} name - Collection name
@@ -408,75 +366,6 @@ describe('Meilisearch features', () => {
         })
       })
 
-      it('displays the number of indexed documents for each collection', () => {
-        // This test enables all collections one at a time to verify counts
-        // First, we need to sync plugin store with Meilisearch by disabling all via UI
-        cy.clearMeilisearchIndexes()
-        visitPluginPage()
-
-        // First pass: ensure all collections are unindexed (sync plugin store)
-        cy.wrap(COLLECTIONS).each(name => {
-          getRow(name)
-            .find('button[role="checkbox"]')
-            .invoke('attr', 'data-state')
-            .then(state => {
-              if (state === 'checked') {
-                getRow(name)
-                  .find('button[role="checkbox"]')
-                  .click({ force: true })
-                // Poll by refreshing page until we see 'No'
-                pollUntilState(name, 'No')
-              }
-            })
-
-          // Verify the row shows 'No'
-          getRow(name, { timeout: TIMEOUT_MS }).should('contain.text', 'No')
-        })
-
-        // Reload once after all unindexing is done (if needed)
-        cy.get('button').then($buttons => {
-          const reloadButton = $buttons.filter(':contains("Reload server")')
-          if (reloadButton.length > 0) {
-            cy.reloadServer()
-            visitPluginPage()
-          }
-        })
-
-        // Second pass: enable each collection sequentially
-        cy.wrap(COLLECTIONS).each(name => {
-          getRow(name)
-            .find('button[role="checkbox"]')
-            .invoke('attr', 'data-state')
-            .then(state => {
-              if (state === 'unchecked') {
-                getRow(name)
-                  .find('button[role="checkbox"]')
-                  .click({ force: true })
-                // Poll by refreshing page until we see 'Yes'
-                pollUntilState(name, 'Yes')
-              }
-            })
-
-          // Verify the row shows 'Yes'
-          getRow(name, { timeout: TIMEOUT_MS }).should('contain.text', 'Yes')
-        })
-
-        // Reload once after all indexing is done (if needed)
-        cy.get('button').then($buttons => {
-          const reloadButton = $buttons.filter(':contains("Reload server")')
-          if (reloadButton.length > 0) {
-            cy.reloadServer()
-            visitPluginPage()
-          }
-        })
-
-        // All collections should show matching counts (X / Y format)
-        cy.wrap(COLLECTIONS).each(name => {
-          getRow(name, { timeout: TIMEOUT_MS }).should($row => {
-            expect($row.text()).to.match(/\d+\s*\/\s*\d+/)
-          })
-        })
-      })
     })
 
     describe('single-type content indexing', () => {

--- a/cypress/e2e/features.cy.js
+++ b/cypress/e2e/features.cy.js
@@ -365,7 +365,6 @@ describe('Meilisearch features', () => {
           expect($row.text()).to.match(/0\s*\/\s*\d+/)
         })
       })
-
     })
 
     describe('single-type content indexing', () => {

--- a/cypress/e2e/permissions.cy.js
+++ b/cypress/e2e/permissions.cy.js
@@ -165,9 +165,6 @@ describe('Permissions', () => {
       // Wait for "Yes" to appear (indexed)
       cy.get('tr:contains("user")').contains('Yes').should('be.visible')
 
-      // Document counts may lag due to async task processing - use retryable assertion
-      cy.get('tr:contains("user")', { timeout: 10000 }).contains('1 / 1')
-
       // Hooks column may show "Hooked" or "Reload needed" due to eventual consistency
       cy.get('tr:contains("user")').then($row => {
         if ($row.text().includes('Reload needed')) {
@@ -193,7 +190,6 @@ describe('Permissions', () => {
       cy.reload()
 
       cy.get('tr:contains("user")').contains('Yes').should('be.visible')
-      cy.get('tr:contains("user")').contains('1 / 1').should('be.visible')
       cy.get('tr:contains("user")').contains('Hooked').should('be.visible')
     })
 

--- a/server/src/__tests__/content-types.test.js
+++ b/server/src/__tests__/content-types.test.js
@@ -83,6 +83,36 @@ describe('Tests content types', () => {
     expect(count).toEqual(1)
   })
 
+  test('numberOfEntries normalizes all locale to wildcard fetch queries', async () => {
+    const customStrapi = createStrapiMock({})
+    const findMany = jest.fn(() => [])
+    customStrapi.documents.mockImplementation(() => ({
+      findMany,
+      findOne: jest.fn(() => null),
+      count: jest.fn(() => 3),
+    }))
+    const contentTypeServices = createContentTypeService({
+      strapi: customStrapi,
+    })
+
+    const count = await contentTypeServices.numberOfEntries({
+      contentType: 'api::restaurant.restaurant',
+      locale: 'all',
+    })
+
+    expect(count).toEqual(0)
+    expect(findMany).toHaveBeenCalledWith({
+      fields: '*',
+      start: 0,
+      limit: 500,
+      filters: {},
+      sort: 'id',
+      populate: '*',
+      status: 'published',
+      locale: '*',
+    })
+  })
+
   test('Test total number of entries', async () => {
     const contentTypeServices = createContentTypeService({
       strapi: strapiMock,
@@ -97,6 +127,71 @@ describe('Tests content types', () => {
     })
 
     expect(count).toEqual(2)
+  })
+
+  test('totalNumberOfEntries forwards wildcard locale to each wildcard fetch', async () => {
+    const customStrapi = createStrapiMock({})
+    const findManyCalls = []
+    customStrapi.documents.mockImplementation(contentTypeUid => ({
+      findMany: jest.fn(query => {
+        findManyCalls.push({ contentTypeUid, query })
+        return []
+      }),
+      findOne: jest.fn(() => null),
+      count: jest.fn(() => 1),
+    }))
+    const contentTypeServices = createContentTypeService({
+      strapi: customStrapi,
+    })
+
+    await contentTypeServices.totalNumberOfEntries({
+      contentTypes: ['api::restaurant.restaurant', 'api::movie.movie'],
+      locale: 'all',
+    })
+
+    expect(findManyCalls).toHaveLength(2)
+    expect(findManyCalls.map(({ query }) => query.locale)).toEqual(['*', '*'])
+  })
+
+  test('totalNumberOfEntries uses fetched wildcard rows when count underestimates', async () => {
+    const getTotalForLocale = async locale => {
+      const customStrapi = createStrapiMock({})
+      const count = jest.fn(() => 1)
+      const findMany = jest
+        .fn()
+        .mockImplementationOnce(() => [{ id: 1 }, { id: 2 }])
+        .mockImplementationOnce(() => [{ id: 3 }, { id: 4 }])
+        .mockImplementationOnce(() => [])
+      customStrapi.documents.mockImplementation(() => ({
+        findMany,
+        findOne: jest.fn(() => null),
+        count,
+      }))
+      const contentTypeServices = createContentTypeService({
+        strapi: customStrapi,
+      })
+
+      const total = await contentTypeServices.totalNumberOfEntries({
+        contentTypes: ['api::restaurant.restaurant'],
+        locale,
+      })
+
+      return { total, findMany }
+    }
+
+    const wildcardResult = await getTotalForLocale('*')
+    const aliasResult = await getTotalForLocale('all')
+
+    expect(wildcardResult.total).toEqual(4)
+    expect(aliasResult.total).toEqual(4)
+    expect(wildcardResult.findMany).toHaveBeenCalledTimes(3)
+    expect(aliasResult.findMany).toHaveBeenCalledTimes(3)
+    expect(
+      wildcardResult.findMany.mock.calls.map(([query]) => query.locale),
+    ).toEqual(['*', '*', '*'])
+    expect(
+      aliasResult.findMany.mock.calls.map(([query]) => query.locale),
+    ).toEqual(['*', '*', '*'])
   })
 
   test('Test fetching entries of a content type with default parameters', async () => {
@@ -243,6 +338,34 @@ describe('Tests content types', () => {
 
     expect(entries[0].id).toEqual(2)
     expect(entries[0].contentType).toEqual(contentType)
+  })
+
+  test('actionInBatches keeps fetching wildcard pages until empty', async () => {
+    const customStrapi = createStrapiMock({})
+    const count = jest.fn(() => 2)
+    const findMany = jest.fn(({ start }) => {
+      if (start === 0) return [{ id: 1 }, { id: 2 }]
+      if (start === 2) return [{ id: 3 }, { id: 4 }]
+      return []
+    })
+    customStrapi.documents.mockImplementation(() => ({
+      findMany,
+      findOne: jest.fn(() => null),
+      count,
+    }))
+    const contentTypeServices = createContentTypeService({
+      strapi: customStrapi,
+    })
+
+    // Count is intentionally lower than wildcard pages to reproduce early stop.
+    const entries = await contentTypeServices.actionInBatches({
+      contentType: 'api::restaurant.restaurant',
+      entriesQuery: { locale: '*', limit: 2 },
+      callback: ({ entries }) => entries.map(entry => entry.id),
+    })
+
+    expect(entries).toEqual([1, 2, 3, 4])
+    expect(findMany).toHaveBeenCalledTimes(3)
   })
 
   test('getEntry returns null when entry is not found', async () => {

--- a/server/src/__tests__/content-types.test.js
+++ b/server/src/__tests__/content-types.test.js
@@ -108,7 +108,7 @@ describe('Tests content types', () => {
       limit: 500,
       filters: {},
       sort: 'id',
-      populate: false,
+      populate: {},
       status: 'published',
       locale: '*',
     })
@@ -148,9 +148,9 @@ describe('Tests content types', () => {
         locale: query.locale,
       })),
     ).toEqual([
-      { fields: ['documentId'], populate: false, locale: '*' },
-      { fields: ['documentId'], populate: false, locale: '*' },
-      { fields: ['documentId'], populate: false, locale: '*' },
+      { fields: ['documentId'], populate: {}, locale: '*' },
+      { fields: ['documentId'], populate: {}, locale: '*' },
+      { fields: ['documentId'], populate: {}, locale: '*' },
     ])
   })
 

--- a/server/src/__tests__/content-types.test.js
+++ b/server/src/__tests__/content-types.test.js
@@ -83,34 +83,75 @@ describe('Tests content types', () => {
     expect(count).toEqual(1)
   })
 
-  test('numberOfEntries normalizes all locale to wildcard fetch queries', async () => {
+  test('numberOfEntries normalizes `all` locale to wildcard fetch queries', async () => {
     const customStrapi = createStrapiMock({})
     const findMany = jest.fn(() => [])
+    const count = jest.fn(() => 3)
     customStrapi.documents.mockImplementation(() => ({
       findMany,
       findOne: jest.fn(() => null),
-      count: jest.fn(() => 3),
+      count,
     }))
     const contentTypeServices = createContentTypeService({
       strapi: customStrapi,
     })
 
-    const count = await contentTypeServices.numberOfEntries({
+    const entryCount = await contentTypeServices.numberOfEntries({
       contentType: 'api::restaurant.restaurant',
       locale: 'all',
     })
 
-    expect(count).toEqual(0)
+    expect(entryCount).toEqual(0)
     expect(findMany).toHaveBeenCalledWith({
-      fields: '*',
+      fields: ['documentId'],
       start: 0,
       limit: 500,
       filters: {},
       sort: 'id',
-      populate: '*',
+      populate: false,
       status: 'published',
       locale: '*',
     })
+    expect(count).not.toHaveBeenCalled()
+  })
+
+  test('numberOfEntries uses lean wildcard batching for `*` locale', async () => {
+    const customStrapi = createStrapiMock({})
+    const findMany = jest
+      .fn()
+      .mockImplementationOnce(() => [
+        { documentId: 'doc-1' },
+        { documentId: 'doc-2' },
+      ])
+      .mockImplementationOnce(() => [{ documentId: 'doc-3' }])
+      .mockImplementationOnce(() => [])
+    customStrapi.documents.mockImplementation(() => ({
+      findMany,
+      findOne: jest.fn(() => null),
+      count: jest.fn(() => 1),
+    }))
+    const contentTypeServices = createContentTypeService({
+      strapi: customStrapi,
+    })
+
+    const entryCount = await contentTypeServices.numberOfEntries({
+      contentType: 'api::restaurant.restaurant',
+      locale: '*',
+    })
+
+    expect(entryCount).toEqual(3)
+    expect(findMany).toHaveBeenCalledTimes(3)
+    expect(
+      findMany.mock.calls.map(([query]) => ({
+        fields: query.fields,
+        populate: query.populate,
+        locale: query.locale,
+      })),
+    ).toEqual([
+      { fields: ['documentId'], populate: false, locale: '*' },
+      { fields: ['documentId'], populate: false, locale: '*' },
+      { fields: ['documentId'], populate: false, locale: '*' },
+    ])
   })
 
   test('Test total number of entries', async () => {

--- a/server/src/__tests__/content-types.test.js
+++ b/server/src/__tests__/content-types.test.js
@@ -368,6 +368,37 @@ describe('Tests content types', () => {
     expect(findMany).toHaveBeenCalledTimes(3)
   })
 
+  test('actionInBatches keeps loop pagination when entriesQuery.start is provided', async () => {
+    const customStrapi = createStrapiMock({})
+    let repeatedStartCalls = 0
+    const findMany = jest.fn(({ start }) => {
+      if (start === 2) {
+        repeatedStartCalls += 1
+        if (repeatedStartCalls === 1) return [{ id: 3 }, { id: 4 }]
+        return [{ id: 99 }]
+      }
+      if (start === 4) return [{ id: 5 }]
+      return []
+    })
+    customStrapi.documents.mockImplementation(() => ({
+      findMany,
+      findOne: jest.fn(() => null),
+      count: jest.fn(() => 3),
+    }))
+    const contentTypeServices = createContentTypeService({
+      strapi: customStrapi,
+    })
+
+    const entries = await contentTypeServices.actionInBatches({
+      contentType: 'api::restaurant.restaurant',
+      entriesQuery: { start: 2, limit: 2 },
+      callback: ({ entries }) => entries.map(entry => entry.id),
+    })
+
+    expect(entries).toEqual([3, 4, 5])
+    expect(findMany.mock.calls.map(([query]) => query.start)).toEqual([2, 4])
+  })
+
   test('getEntry returns null when entry is not found', async () => {
     const customStrapi = createStrapiMock({})
     // Override findOne to return null (entry not found)

--- a/server/src/services/content-types/content-types.js
+++ b/server/src/services/content-types/content-types.js
@@ -117,7 +117,7 @@ export default ({ strapi }) => ({
           entriesQuery: {
             ...queryOptions,
             fields: ['documentId'],
-            populate: false,
+            populate: {},
           },
           callback: ({ entries }) => entries.length,
         })

--- a/server/src/services/content-types/content-types.js
+++ b/server/src/services/content-types/content-types.js
@@ -114,7 +114,11 @@ export default ({ strapi }) => ({
       if (queryOptions.locale === '*') {
         const batchCounts = await this.actionInBatches({
           contentType,
-          entriesQuery: queryOptions,
+          entriesQuery: {
+            ...queryOptions,
+            fields: ['documentId'],
+            populate: false,
+          },
           callback: ({ entries }) => entries.length,
         })
 

--- a/server/src/services/content-types/content-types.js
+++ b/server/src/services/content-types/content-types.js
@@ -1,3 +1,5 @@
+import { normalizeEntryLocale, normalizeEntryScope } from './entry-query'
+
 const IGNORED_PLUGINS = [
   'admin',
   'upload',
@@ -88,7 +90,9 @@ export default ({ strapi }) => ({
    *
    * @param  {object} options
    * @param  {string} options.contentType - Name of the contentType.
-   * @param  {object} [options.where] - Filter condition
+   * @param  {object} [options.filters] - Filter condition.
+   * @param  {string} [options.status='published'] - Publication state.
+   * @param  {string} [options.locale] - Locale to query.
    *
    * @returns  {Promise<number>} number of entries in the content type.
    */
@@ -96,15 +100,28 @@ export default ({ strapi }) => ({
     contentType,
     filters = {},
     status = 'published',
+    locale,
   }) {
     const contentTypeUid = this.getContentTypeUid({ contentType })
     if (contentTypeUid === undefined) return 0
+    const queryOptions = normalizeEntryScope({
+      filters,
+      status,
+      locale,
+    })
 
     try {
-      const count = await strapi.documents(contentTypeUid).count({
-        filters,
-        status,
-      })
+      if (queryOptions.locale === '*') {
+        const batchCounts = await this.actionInBatches({
+          contentType,
+          entriesQuery: queryOptions,
+          callback: ({ entries }) => entries.length,
+        })
+
+        return batchCounts.reduce((total, count) => total + count, 0)
+      }
+
+      const count = await strapi.documents(contentTypeUid).count(queryOptions)
 
       return count
     } catch (e) {
@@ -118,7 +135,9 @@ export default ({ strapi }) => ({
    *
    * @param  {object} options
    * @param  {string[]} options.contentTypes - Names of the contentType.
-   * @param  {object} [options.where] - Filter condition
+   * @param  {object} [options.filters] - Filter condition.
+   * @param  {string} [options.status='published'] - Publication state.
+   * @param  {string} [options.locale] - Locale to query.
    *
    * @returns {Promise<number>} Total entries number of the content types.
    */
@@ -126,10 +145,19 @@ export default ({ strapi }) => ({
     contentTypes,
     filters = {},
     status = 'published',
+    locale,
   }) {
+    const normalizedEntryScope = normalizeEntryScope({
+      filters,
+      status,
+      locale,
+    })
     let numberOfEntries = await Promise.all(
       contentTypes.map(async contentType =>
-        this.numberOfEntries({ contentType, filters, status }),
+        this.numberOfEntries({
+          contentType,
+          ...normalizedEntryScope,
+        }),
       ),
     )
     const entriesSum = numberOfEntries.reduce((acc, curr) => acc + curr, 0)
@@ -158,7 +186,13 @@ export default ({ strapi }) => ({
       status = 'published',
       locale,
     } = entriesQuery
-    const queryOptions = { documentId, fields, populate, status, locale }
+    const queryOptions = {
+      documentId,
+      fields,
+      populate,
+      status,
+      locale: normalizeEntryLocale(locale),
+    }
     const contentTypeUid = this.getContentTypeUid({ contentType })
     if (contentTypeUid === undefined) return null
 
@@ -204,16 +238,21 @@ export default ({ strapi }) => ({
   }) {
     const contentTypeUid = this.getContentTypeUid({ contentType })
     if (contentTypeUid === undefined) return []
+    const normalizedEntryScope = normalizeEntryScope({
+      filters,
+      status,
+      locale,
+    })
 
     const queryOptions = {
       fields: fields || '*',
       start,
       limit,
-      filters,
+      filters: normalizedEntryScope.filters,
       sort,
       populate,
-      status,
-      locale,
+      status: normalizedEntryScope.status,
+      locale: normalizedEntryScope.locale,
     }
 
     const entries = await strapi
@@ -241,26 +280,37 @@ export default ({ strapi }) => ({
     callback = () => {},
     entriesQuery = {},
   }) {
-    const batchSize = entriesQuery.limit || 500
-    // Need total number of entries in contentType
-    const entries_count = await this.numberOfEntries({
-      contentType,
-      ...entriesQuery,
+    const normalizedEntryScope = normalizeEntryScope({
+      filters: entriesQuery.filters,
+      status: entriesQuery.status,
+      locale: entriesQuery.locale,
     })
+    const normalizedEntriesQuery = {
+      ...entriesQuery,
+      ...normalizedEntryScope,
+    }
+    const batchSize = normalizedEntriesQuery.limit || 500
+    const shouldIterateUntilEmpty = normalizedEntriesQuery.locale === '*'
+    let start = normalizedEntriesQuery.start || 0
     const cbResponse = []
-    for (let index = 0; index < entries_count; index += batchSize) {
+    // Keep fetching until the source is exhausted because counts can be stale.
+    while (true) {
       const entries =
         (await this.getEntries({
-          start: index,
+          start,
+          limit: batchSize,
           contentType,
-          ...entriesQuery,
+          ...normalizedEntriesQuery,
         })) || []
 
-      if (entries.length > 0) {
-        const info = await callback({ entries, contentType })
-        if (Array.isArray(info)) cbResponse.push(...info)
-        else if (info) cbResponse.push(info)
-      }
+      if (entries.length === 0) break
+
+      const info = await callback({ entries, contentType })
+      if (Array.isArray(info)) cbResponse.push(...info)
+      else if (info) cbResponse.push(info)
+
+      if (!shouldIterateUntilEmpty && entries.length < batchSize) break
+      start += batchSize
     }
     return cbResponse
   },

--- a/server/src/services/content-types/content-types.js
+++ b/server/src/services/content-types/content-types.js
@@ -289,9 +289,14 @@ export default ({ strapi }) => ({
       ...entriesQuery,
       ...normalizedEntryScope,
     }
-    const batchSize = normalizedEntriesQuery.limit || 500
-    const shouldIterateUntilEmpty = normalizedEntriesQuery.locale === '*'
-    let start = normalizedEntriesQuery.start || 0
+    const {
+      start: initialStart,
+      limit: initialLimit,
+      ...baseQuery
+    } = normalizedEntriesQuery
+    const batchSize = initialLimit ?? 500
+    const shouldIterateUntilEmpty = baseQuery.locale === '*'
+    let start = initialStart ?? 0
     const cbResponse = []
     // Keep fetching until the source is exhausted because counts can be stale.
     while (true) {
@@ -300,7 +305,7 @@ export default ({ strapi }) => ({
           start,
           limit: batchSize,
           contentType,
-          ...normalizedEntriesQuery,
+          ...baseQuery,
         })) || []
 
       if (entries.length === 0) break

--- a/server/src/services/content-types/entry-query.js
+++ b/server/src/services/content-types/entry-query.js
@@ -1,0 +1,31 @@
+/**
+ * Normalize locale values so wildcard semantics stay consistent across queries.
+ *
+ * @param {string | undefined} locale - Locale value used in entry queries.
+ *
+ * @returns {string | undefined} Normalized locale.
+ */
+export const normalizeEntryLocale = locale => {
+  if (locale === 'all') return '*'
+  return locale
+}
+
+/**
+ * Build normalized defaults shared by count and fetch entry queries.
+ *
+ * @param {object} [options={}] - Query scope options.
+ * @param {object} [options.filters={}] - Filter conditions.
+ * @param {string} [options.status='published'] - Publication state.
+ * @param {string} [options.locale] - Locale to query.
+ *
+ * @returns {{ filters: object, status: string, locale: string | undefined }} Normalized entry scope.
+ */
+export const normalizeEntryScope = (options = {}) => {
+  const { filters = {}, status = 'published', locale } = options
+
+  return {
+    filters,
+    status,
+    locale: normalizeEntryLocale(locale),
+  }
+}

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -1,3 +1,5 @@
+import { isWildcardLocale } from '../meilisearch/config'
+
 export default async function registerDocumentMiddleware({ strapi }) {
   if (!strapi?.documents || typeof strapi.documents.use !== 'function') {
     return
@@ -173,8 +175,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
       ]
 
       const entriesQuery = meilisearch.entriesQuery({ contentType })
-      const shouldDeleteByLocale =
-        entriesQuery.locale === '*' || entriesQuery.locale === 'all'
+      const shouldDeleteByLocale = isWildcardLocale(entriesQuery.locale)
       const { status } = entriesQuery || {}
       const statusFilter =
         typeof status === 'string' && status.length > 0 ? { status } : {}

--- a/server/src/services/meilisearch/config.js
+++ b/server/src/services/meilisearch/config.js
@@ -1,6 +1,14 @@
 import { isObject } from '../../utils'
+import { normalizeEntryLocale } from '../content-types/entry-query'
 
-export const isWildcardLocale = locale => locale === 'all' || locale === '*'
+/**
+ * Determine whether a locale value targets every locale variant.
+ *
+ * @param {string | undefined} locale - Locale configured in entries queries.
+ *
+ * @returns {boolean} True when locale resolves to the wildcard marker.
+ */
+export const isWildcardLocale = locale => normalizeEntryLocale(locale) === '*'
 /**
  * Log an error message on a failed action on a contentType.
  *


### PR DESCRIPTION
# Description

## Why

Fixes #1026 
Fixes #1038 

## How

TBD

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide
- [x] ⚠️⚠️ **I have run Cypress E2E tests locally** ⚠️⚠️

> [!warning]
> Cypress tests are currently flaky in CI. Until they are fixed, we require that you paste your local Cypress logs to encourage local testing.

**Output from `yarn cypress run`:**

```
# Paste cypress run output here
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `locale` parameter to entry counting and querying APIs

* **Improvements**
  * Enhanced wildcard locale handling for more efficient entry enumeration
  * Unified locale normalization logic across entry management services

* **Tests**
  * Significantly expanded Jest coverage for wildcard locale scenarios and batch operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->