### PR TITLE
Fix draft and publish i18n compatibility

### DIFF
--- a/server/src/__tests__/content-types.test.js
+++ b/server/src/__tests__/content-types.test.js
@@ -194,7 +194,7 @@ describe('Tests content types', () => {
     expect(findManyCalls.map(({ query }) => query.locale)).toEqual(['*', '*'])
   })
 
-  test('totalNumberOfEntries uses fetched wildcard rows when count underestimates', async () => {
+  test('totalNumberOfEntries uses fetched wildcard entries when count underestimates', async () => {
     const getTotalForLocale = async locale => {
       const customStrapi = createStrapiMock({})
       const count = jest.fn(() => 1)

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -1022,6 +1022,113 @@ describe('Document Service Middleware', () => {
         ],
       })
     })
+
+    test('discardDraft fallback overrides wildcard index locale with action locale', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 205,
+            documentId: 'doc-24',
+            locale: 'fr',
+            publishedAt: null,
+            title: 'French draft fallback',
+          }),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-24', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-24',
+        versions: [{ id: 999, documentId: 'other-doc', locale: 'fr' }],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-24',
+        entriesQuery: { status: 'draft', locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [
+          expect.objectContaining({ documentId: 'doc-24', locale: 'fr' }),
+        ],
+      })
+    })
+
+    test('draft index publish with wildcard locale does not fan out published variants', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 206,
+            documentId: 'doc-25',
+            locale: 'en',
+            publishedAt: null,
+            title: 'English draft fallback',
+          }),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-25', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-25',
+        versions: [
+          {
+            id: 501,
+            documentId: 'doc-25',
+            locale: 'en',
+            publishedAt: '2024-01-01',
+          },
+          {
+            id: 502,
+            documentId: 'doc-25',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-25',
+        entriesQuery: { status: 'draft', locale: '*' },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [
+          expect.objectContaining({ id: 206, locale: 'en', publishedAt: null }),
+        ],
+      })
+    })
   })
 
   describe('wildcard locale fallback reads', () => {
@@ -1104,6 +1211,51 @@ describe('Document Service Middleware', () => {
         entriesQuery: { locale: 'fr' },
       })
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+    })
+
+    test('update prefers locale-matching result candidate for locale-scoped action', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'update',
+        params: { documentId: 'doc-32', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-32',
+        versions: [
+          {
+            id: 601,
+            documentId: 'doc-32',
+            locale: 'en',
+            publishedAt: '2024-01-01',
+          },
+          {
+            id: 602,
+            documentId: 'doc-32',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).not.toHaveBeenCalled()
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [expect.objectContaining({ id: 602, locale: 'fr' })],
+      })
     })
 
     test('publish fallback uses action locale', async () => {

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -158,7 +158,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('indexes the published Strapi row after publish completes', async () => {
+  test('indexes the published Strapi entry after publish completes', async () => {
     const {
       strapi,
       middlewareFn,
@@ -191,7 +191,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('keeps index unchanged when update yields no indexable Strapi row', async () => {
+  test('keeps index unchanged when update yields no indexable Strapi entry', async () => {
     const {
       strapi,
       middlewareFn,
@@ -218,7 +218,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('keeps published-only sync unchanged when update has no published Strapi row', async () => {
+  test('keeps published-only sync unchanged when update has no published Strapi entry', async () => {
     const {
       strapi,
       middlewareFn,
@@ -314,7 +314,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('discardDraft removes indexed records when sync targets published rows', async () => {
+  test('discardDraft removes indexed records when sync targets published entries', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
 
@@ -336,7 +336,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('update indexes the published Strapi row even when action result id is draft', async () => {
+  test('update indexes the published Strapi entry even when action result id is draft', async () => {
     const {
       strapi,
       middlewareFn,
@@ -371,7 +371,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('update with no published Strapi row leaves the index unchanged', async () => {
+  test('update with no published Strapi entry leaves the index unchanged', async () => {
     const {
       strapi,
       middlewareFn,
@@ -399,7 +399,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('publish indexes the Strapi row even when the root result has no id', async () => {
+  test('publish indexes the Strapi entry even when the root result has no id', async () => {
     const {
       strapi,
       middlewareFn,
@@ -434,7 +434,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('draft-only sync indexes the draft row from nested versions data', async () => {
+  test('draft-only sync indexes the draft entry from nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
@@ -459,7 +459,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
         {
           id: 100,
           documentId: 'abc',
-          title: 'Draft row',
+          title: 'Draft entry',
           publishedAt: null,
         },
       ],
@@ -474,7 +474,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     expect(contentTypeGetEntry).not.toHaveBeenCalled()
   })
 
-  test('published sync indexes the published row from nested versions data', async () => {
+  test('published sync indexes the published entry from nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
@@ -498,7 +498,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
         {
           id: 200,
           documentId: 'abc',
-          title: 'Published row',
+          title: 'Published entry',
           publishedAt: '2024-02-01',
         },
       ],
@@ -606,7 +606,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
   })
 
   describe('locale-aware removals from Meilisearch', () => {
-    const strapiPublishedLocaleRows = [
+    const strapiPublishedLocaleEntries = [
       {
         id: 101,
         documentId: 'doc-1',
@@ -627,7 +627,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(strapiPublishedLocaleRows),
+              Promise.resolve(strapiPublishedLocaleEntries),
             ),
           })
 
@@ -656,7 +656,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(strapiPublishedLocaleRows),
+              Promise.resolve(strapiPublishedLocaleEntries),
             ),
           })
 
@@ -680,7 +680,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
         })
       })
 
-      test('delete without params.locale removes only the pre-delete row locale', async () => {
+      test('delete without params.locale removes only the pre-delete entry locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -693,7 +693,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
               }),
             ),
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(strapiPublishedLocaleRows),
+              Promise.resolve(strapiPublishedLocaleEntries),
             ),
           })
 
@@ -717,7 +717,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
         })
       })
 
-      test('unpublish without params.locale removes only the pre-delete row locale', async () => {
+      test('unpublish without params.locale removes only the pre-delete entry locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -730,7 +730,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
               }),
             ),
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(strapiPublishedLocaleRows),
+              Promise.resolve(strapiPublishedLocaleEntries),
             ),
           })
 
@@ -804,7 +804,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(strapiPublishedLocaleRows),
+              Promise.resolve(strapiPublishedLocaleEntries),
             ),
           })
 
@@ -829,7 +829,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       })
     })
 
-    describe('when sync config indexes draft rows across locales', () => {
+    describe('when sync config indexes draft entries across locales', () => {
       test('delete with params.locale=* removes all draft locale records', async () => {
         const strapiLocaleVariants = [
           { documentId: 'doc-15', locale: 'en' },
@@ -905,7 +905,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discardDraft is ignored when sync config indexes published rows', async () => {
+    test('discardDraft is ignored when sync config indexes published entries', async () => {
       const {
         strapi,
         middlewareFn,
@@ -932,7 +932,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
 
     test('discardDraft re-indexes only params.locale in draft sync', async () => {
-      const strapiDraftFrenchRow = {
+      const strapiDraftFrenchEntry = {
         id: 202,
         documentId: 'doc-22',
         locale: 'fr',
@@ -959,7 +959,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       }
       const result = {
         documentId: 'doc-22',
-        versions: [strapiDraftFrenchRow],
+        versions: [strapiDraftFrenchEntry],
       }
 
       await handler(ctx, () => Promise.resolve(result))
@@ -974,14 +974,14 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
 
     test('discardDraft with params.locale=* re-indexes every returned draft locale', async () => {
-      const strapiDraftEnglishRow = {
+      const strapiDraftEnglishEntry = {
         id: 203,
         documentId: 'doc-23',
         locale: 'en',
         publishedAt: null,
         title: 'English draft',
       }
-      const strapiDraftFrenchRow = {
+      const strapiDraftFrenchEntry = {
         id: 204,
         documentId: 'doc-23',
         locale: 'fr',
@@ -1008,7 +1008,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       }
       const result = {
         documentId: 'doc-23',
-        versions: [strapiDraftEnglishRow, strapiDraftFrenchRow],
+        versions: [strapiDraftEnglishEntry, strapiDraftFrenchEntry],
       }
 
       await handler(ctx, () => Promise.resolve(result))
@@ -1132,7 +1132,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
   })
 
   describe('locale=* sync re-fetch behavior', () => {
-    test('create re-fetches the Strapi row with params.locale when needed', async () => {
+    test('create re-fetches the Strapi entry with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1170,7 +1170,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update re-fetches the Strapi row with params.locale when needed', async () => {
+    test('update re-fetches the Strapi entry with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1213,7 +1213,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update uses the params.locale row from result before re-fetching', async () => {
+    test('update uses the params.locale entry from result before re-fetching', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1258,7 +1258,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
       })
     })
 
-    test('publish re-fetches the Strapi row with params.locale when needed', async () => {
+    test('publish re-fetches the Strapi entry with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1356,15 +1356,15 @@ describe('Document Service to Meilisearch sync middleware', () => {
   })
 
   describe('publish fan-out across locales', () => {
-    test('publish with params.locale=* indexes every returned published locale row', async () => {
-      const strapiPublishedEnglishRow = {
+    test('publish with params.locale=* indexes every returned published locale entry', async () => {
+      const strapiPublishedEnglishEntry = {
         id: 401,
         documentId: 'doc-40',
         locale: 'en',
         publishedAt: '2024-01-01',
         title: 'English published',
       }
-      const strapiPublishedFrenchRow = {
+      const strapiPublishedFrenchEntry = {
         id: 402,
         documentId: 'doc-40',
         locale: 'fr',
@@ -1387,14 +1387,14 @@ describe('Document Service to Meilisearch sync middleware', () => {
       }
       const result = {
         documentId: 'doc-40',
-        versions: [strapiPublishedEnglishRow, strapiPublishedFrenchRow],
+        versions: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
       }
 
       await handler(ctx, () => Promise.resolve(result))
 
       expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
         contentType: ctx.uid,
-        entries: [strapiPublishedEnglishRow, strapiPublishedFrenchRow],
+        entries: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
       })
     })
   })

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -692,6 +692,422 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
+  describe('locale-aware delete actions', () => {
+    const publishedLocaleEntries = [
+      {
+        id: 101,
+        documentId: 'doc-1',
+        locale: 'en',
+        publishedAt: '2024-01-01',
+      },
+      {
+        id: 102,
+        documentId: 'doc-1',
+        locale: 'fr',
+        publishedAt: '2024-01-01',
+      },
+    ]
+
+    test('unpublish removes only the requested locale when all locales are indexed', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        deleteEntriesFromMeiliSearch,
+        contentTypeGetEntries,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+        contentTypeGetEntries: jest.fn(() =>
+          Promise.resolve(publishedLocaleEntries),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'unpublish',
+        params: { documentId: 'doc-1', locale: 'fr' },
+      }
+      const result = { documentId: 'doc-1' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntries).toHaveBeenCalled()
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-1'],
+        entriesQuery: { locale: '*' },
+        locales: ['fr'],
+      })
+    })
+
+    test('unpublish removes all locales when action locale is wildcard', async () => {
+      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+        createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntries: jest.fn(() =>
+            Promise.resolve(publishedLocaleEntries),
+          ),
+        })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'unpublish',
+        params: { documentId: 'doc-1', locale: '*' },
+      }
+      const result = { documentId: 'doc-1' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-1'],
+        entriesQuery: { locale: '*' },
+        locales: ['en', 'fr'],
+      })
+    })
+
+    test('unpublish without locale removes only the default locale', async () => {
+      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+        createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() =>
+            Promise.resolve({
+              id: 101,
+              documentId: 'doc-1',
+              locale: 'en',
+              publishedAt: '2024-01-01',
+            }),
+          ),
+          contentTypeGetEntries: jest.fn(() =>
+            Promise.resolve(publishedLocaleEntries),
+          ),
+        })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'unpublish',
+        params: { documentId: 'doc-1' },
+      }
+      const result = { documentId: 'doc-1' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-1'],
+        entriesQuery: { locale: '*' },
+        locales: ['en'],
+      })
+    })
+
+    test('delete removes only the requested locale when all locales are indexed', async () => {
+      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+        createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntries: jest.fn(() =>
+            Promise.resolve(publishedLocaleEntries),
+          ),
+        })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'delete',
+        params: { documentId: 'doc-1', locale: 'fr' },
+      }
+      const result = { documentId: 'doc-1' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-1'],
+        entriesQuery: { locale: '*' },
+        locales: ['fr'],
+      })
+    })
+
+    test('delete without locale removes only the default locale', async () => {
+      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+        createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() =>
+            Promise.resolve({
+              id: 101,
+              documentId: 'doc-1',
+              locale: 'en',
+              publishedAt: '2024-01-01',
+            }),
+          ),
+          contentTypeGetEntries: jest.fn(() =>
+            Promise.resolve(publishedLocaleEntries),
+          ),
+        })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'delete',
+        params: { documentId: 'doc-1' },
+      }
+      const result = { documentId: 'doc-1' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-1'],
+        entriesQuery: { locale: '*' },
+        locales: ['en'],
+      })
+    })
+  })
+
+  describe('draft-and-publish document actions', () => {
+    test('unpublish does not call meilisearch when indexing drafts', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'draft' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'unpublish',
+        params: { documentId: 'doc-20', locale: 'fr' },
+      }
+      const result = { documentId: 'doc-20', locale: 'fr' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+    })
+
+    test('discard draft does not call meilisearch in published indexing mode', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'published' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-21', locale: 'fr' },
+      }
+      const result = { documentId: 'doc-21', locale: 'fr' }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+    })
+
+    test('discard draft updates only the requested locale when indexing drafts', async () => {
+      const draftFrenchEntry = {
+        id: 202,
+        documentId: 'doc-22',
+        locale: 'fr',
+        publishedAt: null,
+        title: 'French draft',
+      }
+
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'draft', locale: 'fr' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-22', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-22',
+        versions: [draftFrenchEntry],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [expect.objectContaining({ documentId: 'doc-22', locale: 'fr' })],
+      })
+    })
+
+    test('discard draft updates all locale drafts when indexing drafts for every locale', async () => {
+      const draftEnglishEntry = {
+        id: 203,
+        documentId: 'doc-23',
+        locale: 'en',
+        publishedAt: null,
+        title: 'English draft',
+      }
+      const draftFrenchEntry = {
+        id: 204,
+        documentId: 'doc-23',
+        locale: 'fr',
+        publishedAt: null,
+        title: 'French draft',
+      }
+
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-23', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-23',
+        versions: [draftEnglishEntry, draftFrenchEntry],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [
+          expect.objectContaining({ documentId: 'doc-23', locale: 'en' }),
+          expect.objectContaining({ documentId: 'doc-23', locale: 'fr' }),
+        ],
+      })
+    })
+  })
+
+  describe('wildcard locale indexing fallbacks', () => {
+    test.each(['create', 'update', 'publish'])(
+      'uses action locale for fallback getEntry on %s',
+      async action => {
+        const {
+          strapi,
+          middlewareFn,
+          updateEntriesInMeilisearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() =>
+            Promise.resolve({
+              id: 301,
+              documentId: 'doc-30',
+              locale: 'fr',
+              publishedAt: '2024-01-01',
+            }),
+          ),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action,
+          params: { documentId: 'doc-30', locale: 'fr' },
+        }
+        const result = {
+          documentId: 'doc-30',
+          versions: [{ id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' }],
+        }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-30',
+          entriesQuery: { locale: 'fr' },
+        })
+        expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+      },
+    )
+
+    test('publish updates all localized versions when action locale is wildcard', async () => {
+      const publishedEnglishEntry = {
+        id: 401,
+        documentId: 'doc-40',
+        locale: 'en',
+        publishedAt: '2024-01-01',
+        title: 'English published',
+      }
+      const publishedFrenchEntry = {
+        id: 402,
+        documentId: 'doc-40',
+        locale: 'fr',
+        publishedAt: '2024-01-01',
+        title: 'French published',
+      }
+
+      const { strapi, middlewareFn, updateEntriesInMeilisearch, contentTypeGetEntry } =
+        createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+        })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-40', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-40',
+        versions: [publishedEnglishEntry, publishedFrenchEntry],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).not.toHaveBeenCalled()
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [publishedEnglishEntry, publishedFrenchEntry],
+      })
+    })
+  })
+
   test('logs error but does not throw when Meilisearch call fails', async () => {
     const {
       strapi,

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -314,7 +314,7 @@ describe('Document Service to Meilisearch sync middleware', () => {
     })
   })
 
-  test('discardDraft removes indexed records when sync targets published entries', async () => {
+  test('discardDraft removes indexed records with default sync config (no explicit status)', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
 
@@ -825,6 +825,88 @@ describe('Document Service to Meilisearch sync middleware', () => {
           documentIds: ['doc-1'],
           entriesQuery: { locale: '*' },
           locales: ['en', 'fr'],
+        })
+      })
+
+      test('publish fallback delete with params.locale removes only that locale record', async () => {
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'publish',
+          params: { documentId: 'doc-1', locale: 'fr' },
+        }
+        const result = {
+          documentId: 'doc-1',
+          versions: [
+            {
+              id: 101,
+              documentId: 'doc-1',
+              locale: 'fr',
+              publishedAt: null,
+            },
+          ],
+        }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-1',
+          entriesQuery: { locale: 'fr' },
+        })
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['fr'],
+        })
+      })
+
+      test('create fallback delete with params.locale removes only that locale record', async () => {
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'create',
+          params: { locale: 'fr' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-1',
+          entriesQuery: { locale: 'fr' },
+        })
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['fr'],
         })
       })
     })

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -1,7 +1,7 @@
 import registerDocumentMiddleware from '../services/document-middleware/index.js'
 import { mockLogger } from '../__mocks__/strapi'
 
-describe('Document Service to Meilisearch sync middleware', () => {
+describe('Document Service middleware', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -1,7 +1,7 @@
 import registerDocumentMiddleware from '../services/document-middleware/index.js'
 import { mockLogger } from '../__mocks__/strapi'
 
-describe('Document Service Middleware', () => {
+describe('Document Service to Meilisearch sync middleware', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -90,7 +90,7 @@ describe('Document Service Middleware', () => {
     await expect(registerDocumentMiddleware({ strapi })).resolves.not.toThrow()
   })
 
-  test('processes create action for listened content types after next()', async () => {
+  test('indexes the created Strapi document after create completes', async () => {
     const {
       strapi,
       middlewareFn,
@@ -125,7 +125,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('processes update action for listened content types after next()', async () => {
+  test('re-indexes the Strapi document after update completes', async () => {
     const {
       strapi,
       middlewareFn,
@@ -158,7 +158,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('processes publish action like update for listened content types', async () => {
+  test('indexes the published Strapi row after publish completes', async () => {
     const {
       strapi,
       middlewareFn,
@@ -191,7 +191,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('skips deletion when updated entry is not returned', async () => {
+  test('keeps index unchanged when update yields no indexable Strapi row', async () => {
     const {
       strapi,
       middlewareFn,
@@ -218,7 +218,7 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('does not delete after update when no published entry is returned', async () => {
+  test('keeps published-only sync unchanged when update has no published Strapi row', async () => {
     const {
       strapi,
       middlewareFn,
@@ -246,7 +246,7 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('propagates wildcard entriesQuery when deleting a document', async () => {
+  test('delete forwards locale=* sync config to Meilisearch removal', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs({
         meilisearchEntriesQuery: { locale: '*' },
@@ -270,7 +270,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('processes delete-like actions by removing from Meilisearch', async () => {
+  test('delete removes indexed records for the Strapi document', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
 
@@ -292,7 +292,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('processes unpublish action by removing from Meilisearch', async () => {
+  test('unpublish removes indexed records for the Strapi document', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
 
@@ -314,7 +314,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('processes discardDraft action by removing from Meilisearch', async () => {
+  test('discardDraft removes indexed records when sync targets published rows', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
 
@@ -336,7 +336,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('update action uses id from getEntry, not from action result (D&P fix)', async () => {
+  test('update indexes the published Strapi row even when action result id is draft', async () => {
     const {
       strapi,
       middlewareFn,
@@ -371,7 +371,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('update action does not delete when getEntry returns null (no published version)', async () => {
+  test('update with no published Strapi row leaves the index unchanged', async () => {
     const {
       strapi,
       middlewareFn,
@@ -399,7 +399,7 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('publish action handles result without id at root level', async () => {
+  test('publish indexes the Strapi row even when the root result has no id', async () => {
     const {
       strapi,
       middlewareFn,
@@ -434,7 +434,7 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('draft update prefers nested draft entry over wrapper root', async () => {
+  test('draft-only sync indexes the draft row from nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
@@ -474,7 +474,7 @@ describe('Document Service Middleware', () => {
     expect(contentTypeGetEntry).not.toHaveBeenCalled()
   })
 
-  test('published update prefers nested published entry over wrapper root', async () => {
+  test('published sync indexes the published row from nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
@@ -513,7 +513,7 @@ describe('Document Service Middleware', () => {
     expect(contentTypeGetEntry).not.toHaveBeenCalled()
   })
 
-  test('prefers ctx.params.documentId over result documentId for publish actions', async () => {
+  test('publish uses ctx.params.documentId when result.documentId differs', async () => {
     const {
       strapi,
       middlewareFn,
@@ -605,8 +605,8 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  describe('locale-scoped delete actions', () => {
-    const publishedLocaleEntries = [
+  describe('locale-aware removals from Meilisearch', () => {
+    const strapiPublishedLocaleRows = [
       {
         id: 101,
         documentId: 'doc-1',
@@ -621,13 +621,13 @@ describe('Document Service Middleware', () => {
       },
     ]
 
-    describe('when the index contains all locales', () => {
-      test('delete removes only the requested locale', async () => {
+    describe('when sync config indexes all locales (locale: *)', () => {
+      test('delete with params.locale removes only that locale record', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(publishedLocaleEntries),
+              Promise.resolve(strapiPublishedLocaleRows),
             ),
           })
 
@@ -651,12 +651,12 @@ describe('Document Service Middleware', () => {
         })
       })
 
-      test('unpublish removes only the requested locale', async () => {
+      test('unpublish with params.locale removes only that locale record', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(publishedLocaleEntries),
+              Promise.resolve(strapiPublishedLocaleRows),
             ),
           })
 
@@ -680,7 +680,7 @@ describe('Document Service Middleware', () => {
         })
       })
 
-      test('delete without locale removes only the default locale', async () => {
+      test('delete without params.locale removes only the pre-delete row locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -693,7 +693,7 @@ describe('Document Service Middleware', () => {
               }),
             ),
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(publishedLocaleEntries),
+              Promise.resolve(strapiPublishedLocaleRows),
             ),
           })
 
@@ -717,7 +717,7 @@ describe('Document Service Middleware', () => {
         })
       })
 
-      test('unpublish without locale removes only the default locale', async () => {
+      test('unpublish without params.locale removes only the pre-delete row locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -730,7 +730,7 @@ describe('Document Service Middleware', () => {
               }),
             ),
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(publishedLocaleEntries),
+              Promise.resolve(strapiPublishedLocaleRows),
             ),
           })
 
@@ -754,8 +754,8 @@ describe('Document Service Middleware', () => {
         })
       })
 
-      test('delete with wildcard action locale removes all locales', async () => {
-        const localizedVariants = [
+      test('delete with params.locale=* removes all locale records for the Strapi document', async () => {
+        const strapiLocaleVariants = [
           { documentId: 'doc-15', locale: 'en' },
           { documentId: 'doc-15', locale: 'fr' },
         ]
@@ -768,7 +768,7 @@ describe('Document Service Middleware', () => {
         } = createStrapiStubs({
           meilisearchEntriesQuery: { locale: '*' },
           contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(localizedVariants),
+            Promise.resolve(strapiLocaleVariants),
           ),
         })
 
@@ -799,12 +799,12 @@ describe('Document Service Middleware', () => {
         })
       })
 
-      test('unpublish with wildcard action locale removes all locales', async () => {
+      test('unpublish with params.locale=* removes all locale records for the Strapi document', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
             contentTypeGetEntries: jest.fn(() =>
-              Promise.resolve(publishedLocaleEntries),
+              Promise.resolve(strapiPublishedLocaleRows),
             ),
           })
 
@@ -829,9 +829,9 @@ describe('Document Service Middleware', () => {
       })
     })
 
-    describe('when the index contains draft entries for all locales', () => {
-      test('delete with wildcard action locale resolves draft locale variants', async () => {
-        const localizedVariants = [
+    describe('when sync config indexes draft rows across locales', () => {
+      test('delete with params.locale=* removes all draft locale records', async () => {
+        const strapiLocaleVariants = [
           { documentId: 'doc-15', locale: 'en' },
           { documentId: 'doc-15', locale: 'fr' },
         ]
@@ -844,7 +844,7 @@ describe('Document Service Middleware', () => {
         } = createStrapiStubs({
           meilisearchEntriesQuery: { locale: '*', status: 'draft' },
           contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(localizedVariants),
+            Promise.resolve(strapiLocaleVariants),
           ),
         })
 
@@ -878,8 +878,8 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  describe('draft-and-publish document actions', () => {
-    test('unpublish does not affect draft indexes', async () => {
+  describe('draft/publish lifecycle sync behavior', () => {
+    test('unpublish is ignored when sync config indexes drafts', async () => {
       const {
         strapi,
         middlewareFn,
@@ -905,7 +905,7 @@ describe('Document Service Middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discardDraft does not affect published indexes', async () => {
+    test('discardDraft is ignored when sync config indexes published rows', async () => {
       const {
         strapi,
         middlewareFn,
@@ -931,8 +931,8 @@ describe('Document Service Middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discardDraft updates only the requested draft locale', async () => {
-      const draftFrenchEntry = {
+    test('discardDraft re-indexes only params.locale in draft sync', async () => {
+      const strapiDraftFrenchRow = {
         id: 202,
         documentId: 'doc-22',
         locale: 'fr',
@@ -959,7 +959,7 @@ describe('Document Service Middleware', () => {
       }
       const result = {
         documentId: 'doc-22',
-        versions: [draftFrenchEntry],
+        versions: [strapiDraftFrenchRow],
       }
 
       await handler(ctx, () => Promise.resolve(result))
@@ -973,15 +973,15 @@ describe('Document Service Middleware', () => {
       })
     })
 
-    test('discardDraft with wildcard action locale updates all returned draft locales', async () => {
-      const draftEnglishEntry = {
+    test('discardDraft with params.locale=* re-indexes every returned draft locale', async () => {
+      const strapiDraftEnglishRow = {
         id: 203,
         documentId: 'doc-23',
         locale: 'en',
         publishedAt: null,
         title: 'English draft',
       }
-      const draftFrenchEntry = {
+      const strapiDraftFrenchRow = {
         id: 204,
         documentId: 'doc-23',
         locale: 'fr',
@@ -1008,7 +1008,7 @@ describe('Document Service Middleware', () => {
       }
       const result = {
         documentId: 'doc-23',
-        versions: [draftEnglishEntry, draftFrenchEntry],
+        versions: [strapiDraftEnglishRow, strapiDraftFrenchRow],
       }
 
       await handler(ctx, () => Promise.resolve(result))
@@ -1023,7 +1023,7 @@ describe('Document Service Middleware', () => {
       })
     })
 
-    test('discardDraft fallback overrides wildcard index locale with action locale', async () => {
+    test('discardDraft re-fetches params.locale when result misses that Strapi document', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1070,7 +1070,7 @@ describe('Document Service Middleware', () => {
       })
     })
 
-    test('draft index publish with wildcard locale does not fan out published variants', async () => {
+    test('publish does not fan out published locales when sync config indexes drafts', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1131,8 +1131,8 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  describe('wildcard locale fallback reads', () => {
-    test('create fallback uses action locale from params and documentId from result', async () => {
+  describe('locale=* sync re-fetch behavior', () => {
+    test('create re-fetches the Strapi row with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1170,7 +1170,7 @@ describe('Document Service Middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update fallback uses action locale', async () => {
+    test('update re-fetches the Strapi row with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1213,7 +1213,7 @@ describe('Document Service Middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update prefers locale-matching result candidate for locale-scoped action', async () => {
+    test('update uses the params.locale row from result before re-fetching', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1258,7 +1258,7 @@ describe('Document Service Middleware', () => {
       })
     })
 
-    test('publish fallback uses action locale', async () => {
+    test('publish re-fetches the Strapi row with params.locale when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1301,8 +1301,8 @@ describe('Document Service Middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('fallback preserves entriesQuery options while overriding wildcard locale', async () => {
-      const configuredEntriesQuery = {
+    test('locale=* re-fetch keeps sync query options while narrowing to params.locale', async () => {
+      const configuredSyncQuery = {
         locale: '*',
         status: 'published',
         fields: ['title', 'locale'],
@@ -1315,7 +1315,7 @@ describe('Document Service Middleware', () => {
         updateEntriesInMeilisearch,
         contentTypeGetEntry,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: configuredEntriesQuery,
+        meilisearchEntriesQuery: configuredSyncQuery,
         contentTypeGetEntry: jest.fn(() =>
           Promise.resolve({
             id: 302,
@@ -1347,7 +1347,7 @@ describe('Document Service Middleware', () => {
         contentType: ctx.uid,
         documentId: 'doc-31',
         entriesQuery: {
-          ...configuredEntriesQuery,
+          ...configuredSyncQuery,
           locale: 'fr',
         },
       })
@@ -1355,16 +1355,16 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  describe('multi-locale publish results', () => {
-    test('publish with wildcard action locale indexes every returned version', async () => {
-      const publishedEnglishEntry = {
+  describe('publish fan-out across locales', () => {
+    test('publish with params.locale=* indexes every returned published locale row', async () => {
+      const strapiPublishedEnglishRow = {
         id: 401,
         documentId: 'doc-40',
         locale: 'en',
         publishedAt: '2024-01-01',
         title: 'English published',
       }
-      const publishedFrenchEntry = {
+      const strapiPublishedFrenchRow = {
         id: 402,
         documentId: 'doc-40',
         locale: 'fr',
@@ -1387,14 +1387,14 @@ describe('Document Service Middleware', () => {
       }
       const result = {
         documentId: 'doc-40',
-        versions: [publishedEnglishEntry, publishedFrenchEntry],
+        versions: [strapiPublishedEnglishRow, strapiPublishedFrenchRow],
       }
 
       await handler(ctx, () => Promise.resolve(result))
 
       expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
         contentType: ctx.uid,
-        entries: [publishedEnglishEntry, publishedFrenchEntry],
+        entries: [strapiPublishedEnglishRow, strapiPublishedFrenchRow],
       })
     })
   })

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -270,93 +270,6 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  test('resolves locale variants before deleting when wildcard locale is configured', async () => {
-    const localizedVariants = [
-      { documentId: 'doc-15', locale: 'en' },
-      { documentId: 'doc-15', locale: 'fr' },
-    ]
-
-    const {
-      strapi,
-      middlewareFn,
-      deleteEntriesFromMeiliSearch,
-      contentTypeGetEntries,
-    } = createStrapiStubs({
-      meilisearchEntriesQuery: { locale: '*' },
-      contentTypeGetEntries: jest.fn(() => Promise.resolve(localizedVariants)),
-    })
-
-    await registerDocumentMiddleware({ strapi })
-
-    const handler = middlewareFn()
-    const ctx = {
-      uid: 'api::restaurant.restaurant',
-      action: 'delete',
-      params: { documentId: 'doc-15' },
-    }
-    const result = { id: 15, documentId: 'doc-15' }
-    await handler(ctx, () => Promise.resolve(result))
-
-    expect(contentTypeGetEntries).toHaveBeenCalledWith({
-      contentType: ctx.uid,
-      fields: ['documentId', 'locale'],
-      locale: '*',
-      filters: {
-        documentId: ctx.params.documentId,
-      },
-    })
-    expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-      contentType: ctx.uid,
-      documentIds: [result.documentId],
-      entriesQuery: { locale: '*' },
-      locales: ['en', 'fr'],
-    })
-  })
-
-  test('resolves draft locale variants when wildcard locale & draft status are configured', async () => {
-    const localizedVariants = [
-      { documentId: 'doc-15', locale: 'en' },
-      { documentId: 'doc-15', locale: 'fr' },
-    ]
-
-    const {
-      strapi,
-      middlewareFn,
-      deleteEntriesFromMeiliSearch,
-      contentTypeGetEntries,
-    } = createStrapiStubs({
-      meilisearchEntriesQuery: { locale: '*', status: 'draft' },
-      contentTypeGetEntries: jest.fn(() => Promise.resolve(localizedVariants)),
-    })
-
-    await registerDocumentMiddleware({ strapi })
-
-    const handler = middlewareFn()
-    const ctx = {
-      uid: 'api::restaurant.restaurant',
-      action: 'delete',
-      params: { documentId: 'doc-15' },
-    }
-    const result = { id: 15, documentId: 'doc-15' }
-    await handler(ctx, () => Promise.resolve(result))
-
-    expect(contentTypeGetEntries).toHaveBeenCalledWith({
-      contentType: ctx.uid,
-      fields: ['documentId', 'locale'],
-      locale: '*',
-      status: 'draft',
-      filters: {
-        documentId: ctx.params.documentId,
-      },
-    })
-    expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-      contentType: ctx.uid,
-      documentIds: [result.documentId],
-      entriesQuery: { locale: '*', status: 'draft' },
-      locales: ['en', 'fr'],
-    })
-  })
-
   test('processes delete-like actions by removing from Meilisearch', async () => {
     const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
       createStrapiStubs()
@@ -692,7 +605,7 @@ describe('Document Service Middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  describe('locale-aware delete actions', () => {
+  describe('locale-scoped delete actions', () => {
     const publishedLocaleEntries = [
       {
         id: 101,
@@ -708,175 +621,265 @@ describe('Document Service Middleware', () => {
       },
     ]
 
-    test('unpublish removes only the requested locale when all locales are indexed', async () => {
-      const {
-        strapi,
-        middlewareFn,
-        deleteEntriesFromMeiliSearch,
-        contentTypeGetEntries,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: '*' },
-        contentTypeGetEntries: jest.fn(() =>
-          Promise.resolve(publishedLocaleEntries),
-        ),
+    describe('when the index contains all locales', () => {
+      test('delete removes only the requested locale', async () => {
+        const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+          createStrapiStubs({
+            meilisearchEntriesQuery: { locale: '*' },
+            contentTypeGetEntries: jest.fn(() =>
+              Promise.resolve(publishedLocaleEntries),
+            ),
+          })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'delete',
+          params: { documentId: 'doc-1', locale: 'fr' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['fr'],
+        })
       })
 
-      await registerDocumentMiddleware({ strapi })
+      test('unpublish removes only the requested locale', async () => {
+        const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+          createStrapiStubs({
+            meilisearchEntriesQuery: { locale: '*' },
+            contentTypeGetEntries: jest.fn(() =>
+              Promise.resolve(publishedLocaleEntries),
+            ),
+          })
 
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'unpublish',
-        params: { documentId: 'doc-1', locale: 'fr' },
-      }
-      const result = { documentId: 'doc-1' }
+        await registerDocumentMiddleware({ strapi })
 
-      await handler(ctx, () => Promise.resolve(result))
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'unpublish',
+          params: { documentId: 'doc-1', locale: 'fr' },
+        }
+        const result = { documentId: 'doc-1' }
 
-      expect(contentTypeGetEntries).toHaveBeenCalled()
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-1'],
-        entriesQuery: { locale: '*' },
-        locales: ['fr'],
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['fr'],
+        })
       })
-    })
 
-    test('unpublish removes all locales when action locale is wildcard', async () => {
-      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
-        createStrapiStubs({
+      test('delete without locale removes only the default locale', async () => {
+        const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+          createStrapiStubs({
+            meilisearchEntriesQuery: { locale: '*' },
+            contentTypeGetEntry: jest.fn(() =>
+              Promise.resolve({
+                id: 101,
+                documentId: 'doc-1',
+                locale: 'en',
+                publishedAt: '2024-01-01',
+              }),
+            ),
+            contentTypeGetEntries: jest.fn(() =>
+              Promise.resolve(publishedLocaleEntries),
+            ),
+          })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'delete',
+          params: { documentId: 'doc-1' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['en'],
+        })
+      })
+
+      test('unpublish without locale removes only the default locale', async () => {
+        const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+          createStrapiStubs({
+            meilisearchEntriesQuery: { locale: '*' },
+            contentTypeGetEntry: jest.fn(() =>
+              Promise.resolve({
+                id: 101,
+                documentId: 'doc-1',
+                locale: 'en',
+                publishedAt: '2024-01-01',
+              }),
+            ),
+            contentTypeGetEntries: jest.fn(() =>
+              Promise.resolve(publishedLocaleEntries),
+            ),
+          })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'unpublish',
+          params: { documentId: 'doc-1' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['en'],
+        })
+      })
+
+      test('delete with wildcard action locale removes all locales', async () => {
+        const localizedVariants = [
+          { documentId: 'doc-15', locale: 'en' },
+          { documentId: 'doc-15', locale: 'fr' },
+        ]
+
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntries,
+        } = createStrapiStubs({
           meilisearchEntriesQuery: { locale: '*' },
           contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(publishedLocaleEntries),
+            Promise.resolve(localizedVariants),
           ),
         })
 
-      await registerDocumentMiddleware({ strapi })
+        await registerDocumentMiddleware({ strapi })
 
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'unpublish',
-        params: { documentId: 'doc-1', locale: '*' },
-      }
-      const result = { documentId: 'doc-1' }
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'delete',
+          params: { documentId: 'doc-15', locale: '*' },
+        }
+        const result = { id: 15, documentId: 'doc-15' }
+        await handler(ctx, () => Promise.resolve(result))
 
-      await handler(ctx, () => Promise.resolve(result))
+        expect(contentTypeGetEntries).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          fields: ['documentId', 'locale'],
+          locale: '*',
+          filters: {
+            documentId: ctx.params.documentId,
+          },
+        })
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: [result.documentId],
+          entriesQuery: { locale: '*' },
+          locales: ['en', 'fr'],
+        })
+      })
 
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-1'],
-        entriesQuery: { locale: '*' },
-        locales: ['en', 'fr'],
+      test('unpublish with wildcard action locale removes all locales', async () => {
+        const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+          createStrapiStubs({
+            meilisearchEntriesQuery: { locale: '*' },
+            contentTypeGetEntries: jest.fn(() =>
+              Promise.resolve(publishedLocaleEntries),
+            ),
+          })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'unpublish',
+          params: { documentId: 'doc-1', locale: '*' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-1'],
+          entriesQuery: { locale: '*' },
+          locales: ['en', 'fr'],
+        })
       })
     })
 
-    test('unpublish without locale removes only the default locale', async () => {
-      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
-        createStrapiStubs({
-          meilisearchEntriesQuery: { locale: '*' },
-          contentTypeGetEntry: jest.fn(() =>
-            Promise.resolve({
-              id: 101,
-              documentId: 'doc-1',
-              locale: 'en',
-              publishedAt: '2024-01-01',
-            }),
-          ),
+    describe('when the index contains draft entries for all locales', () => {
+      test('delete with wildcard action locale resolves draft locale variants', async () => {
+        const localizedVariants = [
+          { documentId: 'doc-15', locale: 'en' },
+          { documentId: 'doc-15', locale: 'fr' },
+        ]
+
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntries,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*', status: 'draft' },
           contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(publishedLocaleEntries),
+            Promise.resolve(localizedVariants),
           ),
         })
 
-      await registerDocumentMiddleware({ strapi })
+        await registerDocumentMiddleware({ strapi })
 
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'unpublish',
-        params: { documentId: 'doc-1' },
-      }
-      const result = { documentId: 'doc-1' }
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'delete',
+          params: { documentId: 'doc-15', locale: '*' },
+        }
+        const result = { id: 15, documentId: 'doc-15' }
+        await handler(ctx, () => Promise.resolve(result))
 
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-1'],
-        entriesQuery: { locale: '*' },
-        locales: ['en'],
-      })
-    })
-
-    test('delete removes only the requested locale when all locales are indexed', async () => {
-      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
-        createStrapiStubs({
-          meilisearchEntriesQuery: { locale: '*' },
-          contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(publishedLocaleEntries),
-          ),
+        expect(contentTypeGetEntries).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          fields: ['documentId', 'locale'],
+          locale: '*',
+          status: 'draft',
+          filters: {
+            documentId: ctx.params.documentId,
+          },
         })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'delete',
-        params: { documentId: 'doc-1', locale: 'fr' },
-      }
-      const result = { documentId: 'doc-1' }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-1'],
-        entriesQuery: { locale: '*' },
-        locales: ['fr'],
-      })
-    })
-
-    test('delete without locale removes only the default locale', async () => {
-      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
-        createStrapiStubs({
-          meilisearchEntriesQuery: { locale: '*' },
-          contentTypeGetEntry: jest.fn(() =>
-            Promise.resolve({
-              id: 101,
-              documentId: 'doc-1',
-              locale: 'en',
-              publishedAt: '2024-01-01',
-            }),
-          ),
-          contentTypeGetEntries: jest.fn(() =>
-            Promise.resolve(publishedLocaleEntries),
-          ),
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: [result.documentId],
+          entriesQuery: { locale: '*', status: 'draft' },
+          locales: ['en', 'fr'],
         })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'delete',
-        params: { documentId: 'doc-1' },
-      }
-      const result = { documentId: 'doc-1' }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-1'],
-        entriesQuery: { locale: '*' },
-        locales: ['en'],
       })
     })
   })
 
   describe('draft-and-publish document actions', () => {
-    test('unpublish does not call meilisearch when indexing drafts', async () => {
+    test('unpublish does not affect draft indexes', async () => {
       const {
         strapi,
         middlewareFn,
@@ -902,7 +905,7 @@ describe('Document Service Middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discard draft does not call meilisearch in published indexing mode', async () => {
+    test('discardDraft does not affect published indexes', async () => {
       const {
         strapi,
         middlewareFn,
@@ -928,7 +931,7 @@ describe('Document Service Middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discard draft updates only the requested locale when indexing drafts', async () => {
+    test('discardDraft updates only the requested draft locale', async () => {
       const draftFrenchEntry = {
         id: 202,
         documentId: 'doc-22',
@@ -964,11 +967,13 @@ describe('Document Service Middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
       expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
         contentType: ctx.uid,
-        entries: [expect.objectContaining({ documentId: 'doc-22', locale: 'fr' })],
+        entries: [
+          expect.objectContaining({ documentId: 'doc-22', locale: 'fr' }),
+        ],
       })
     })
 
-    test('discard draft updates all locale drafts when indexing drafts for every locale', async () => {
+    test('discardDraft with wildcard action locale updates all returned draft locales', async () => {
       const draftEnglishEntry = {
         id: 203,
         documentId: 'doc-23',
@@ -1019,52 +1024,187 @@ describe('Document Service Middleware', () => {
     })
   })
 
-  describe('wildcard locale indexing fallbacks', () => {
-    test.each(['create', 'update', 'publish'])(
-      'uses action locale for fallback getEntry on %s',
-      async action => {
-        const {
-          strapi,
-          middlewareFn,
-          updateEntriesInMeilisearch,
-          contentTypeGetEntry,
-        } = createStrapiStubs({
-          meilisearchEntriesQuery: { locale: '*' },
-          contentTypeGetEntry: jest.fn(() =>
-            Promise.resolve({
-              id: 301,
-              documentId: 'doc-30',
-              locale: 'fr',
-              publishedAt: '2024-01-01',
-            }),
-          ),
-        })
+  describe('wildcard locale fallback reads', () => {
+    test('create fallback uses action locale from params and documentId from result', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 301,
+            documentId: 'doc-30',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          }),
+        ),
+      })
 
-        await registerDocumentMiddleware({ strapi })
+      await registerDocumentMiddleware({ strapi })
 
-        const handler = middlewareFn()
-        const ctx = {
-          uid: 'api::restaurant.restaurant',
-          action,
-          params: { documentId: 'doc-30', locale: 'fr' },
-        }
-        const result = {
-          documentId: 'doc-30',
-          versions: [{ id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' }],
-        }
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'create',
+        params: { locale: 'fr' },
+      }
+      const result = { documentId: 'doc-30' }
 
-        await handler(ctx, () => Promise.resolve(result))
+      await handler(ctx, () => Promise.resolve(result))
 
-        expect(contentTypeGetEntry).toHaveBeenCalledWith({
-          contentType: ctx.uid,
-          documentId: 'doc-30',
-          entriesQuery: { locale: 'fr' },
-        })
-        expect(updateEntriesInMeilisearch).toHaveBeenCalled()
-      },
-    )
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-30',
+        entriesQuery: { locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+    })
 
-    test('publish updates all localized versions when action locale is wildcard', async () => {
+    test('update fallback uses action locale', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 301,
+            documentId: 'doc-30',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          }),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'update',
+        params: { documentId: 'doc-30', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-30',
+        versions: [
+          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-30',
+        entriesQuery: { locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+    })
+
+    test('publish fallback uses action locale', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 301,
+            documentId: 'doc-30',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          }),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-30', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-30',
+        versions: [
+          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-30',
+        entriesQuery: { locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+    })
+
+    test('fallback preserves entriesQuery options while overriding wildcard locale', async () => {
+      const configuredEntriesQuery = {
+        locale: '*',
+        status: 'published',
+        fields: ['title', 'locale'],
+        populate: { image: true },
+        filters: { featured: true },
+      }
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: configuredEntriesQuery,
+        contentTypeGetEntry: jest.fn(() =>
+          Promise.resolve({
+            id: 302,
+            documentId: 'doc-31',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          }),
+        ),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-31', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-31',
+        versions: [
+          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-31',
+        entriesQuery: {
+          ...configuredEntriesQuery,
+          locale: 'fr',
+        },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
+    })
+  })
+
+  describe('multi-locale publish results', () => {
+    test('publish with wildcard action locale indexes every returned version', async () => {
       const publishedEnglishEntry = {
         id: 401,
         documentId: 'doc-40',
@@ -1080,7 +1220,7 @@ describe('Document Service Middleware', () => {
         title: 'French published',
       }
 
-      const { strapi, middlewareFn, updateEntriesInMeilisearch, contentTypeGetEntry } =
+      const { strapi, middlewareFn, updateEntriesInMeilisearch } =
         createStrapiStubs({
           meilisearchEntriesQuery: { locale: '*' },
         })
@@ -1100,7 +1240,6 @@ describe('Document Service Middleware', () => {
 
       await handler(ctx, () => Promise.resolve(result))
 
-      expect(contentTypeGetEntry).not.toHaveBeenCalled()
       expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
         contentType: ctx.uid,
         entries: [publishedEnglishEntry, publishedFrenchEntry],

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -1479,6 +1479,99 @@ describe('Document Service to Meilisearch sync middleware', () => {
         entries: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
       })
     })
+
+    test('publish with params.locale=* and concrete sync locale indexes only owned locale', async () => {
+      const strapiPublishedEnglishEntry = {
+        id: 411,
+        documentId: 'doc-41',
+        locale: 'en',
+        publishedAt: '2024-01-01',
+      }
+      const strapiPublishedFrenchEntry = {
+        id: 412,
+        documentId: 'doc-41',
+        locale: 'fr',
+        publishedAt: '2024-01-01',
+      }
+
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: 'fr' },
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-41', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-41',
+        versions: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [strapiPublishedFrenchEntry],
+      })
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+    })
+
+    test('publish with params.locale=* deletes stale owned locale when publish result has no owned locale', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: 'fr' },
+        contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'publish',
+        params: { documentId: 'doc-42', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-42',
+        versions: [
+          {
+            id: 421,
+            documentId: 'doc-42',
+            locale: 'en',
+            publishedAt: '2024-01-01',
+          },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-42',
+        entriesQuery: { locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-42'],
+        entriesQuery: { locale: 'fr' },
+        locales: undefined,
+      })
+    })
   })
 
   test('logs error but does not throw when Meilisearch call fails', async () => {

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -1,7 +1,12 @@
 import registerDocumentMiddleware from '../services/document-middleware/index.js'
 import { mockLogger } from '../__mocks__/strapi'
+import {
+  SYNC_PRESETS,
+  createDraftEntry,
+  createPublishedEntry,
+} from './utils/document-middleware-fixtures.js'
 
-describe('Document Service middleware', () => {
+describe('Meilisearch sync on Strapi document changes', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -226,7 +231,7 @@ describe('Document Service middleware', () => {
       deleteEntriesFromMeiliSearch,
       contentTypeGetEntry,
     } = createStrapiStubs({
-      meilisearchEntriesQuery: { locale: 'fr' },
+      meilisearchEntriesQuery: SYNC_PRESETS.frenchOnly,
     })
 
     contentTypeGetEntry.mockResolvedValueOnce(null)
@@ -560,7 +565,7 @@ describe('Document Service middleware', () => {
     })
   })
 
-  test('does nothing when content type is not listened', async () => {
+  test('skips sync for content types that are not listened', async () => {
     const {
       strapi,
       middlewareFn,
@@ -583,7 +588,7 @@ describe('Document Service middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  test('does nothing when result is missing', async () => {
+  test('skips sync when the document action has no result payload', async () => {
     const {
       strapi,
       middlewareFn,
@@ -605,7 +610,7 @@ describe('Document Service middleware', () => {
     expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
   })
 
-  describe('locale-aware removals from Meilisearch', () => {
+  describe('all-locale index removal behavior', () => {
     const strapiPublishedLocaleEntries = [
       {
         id: 101,
@@ -621,8 +626,8 @@ describe('Document Service middleware', () => {
       },
     ]
 
-    describe('when sync config indexes all locales (locale: *)', () => {
-      test('delete with params.locale removes only that locale record', async () => {
+    describe('all-locale index (locale: *)', () => {
+      test('delete removes only the requested locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -651,7 +656,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('unpublish with params.locale removes only that locale record', async () => {
+      test('unpublish removes only the requested locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -680,7 +685,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('delete without params.locale removes only the pre-delete entry locale', async () => {
+      test('delete without an explicit locale removes the pre-delete locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -717,7 +722,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('unpublish without params.locale removes only the pre-delete entry locale', async () => {
+      test('unpublish without an explicit locale removes the pre-delete locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -754,7 +759,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('delete with params.locale=* removes all locale records for the Strapi document', async () => {
+      test('delete with all-locale action removes every indexed locale', async () => {
         const strapiLocaleVariants = [
           { documentId: 'doc-15', locale: 'en' },
           { documentId: 'doc-15', locale: 'fr' },
@@ -799,7 +804,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('unpublish with params.locale=* removes all locale records for the Strapi document', async () => {
+      test('unpublish with all-locale action removes every indexed locale', async () => {
         const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
           createStrapiStubs({
             meilisearchEntriesQuery: { locale: '*' },
@@ -828,7 +833,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('publish fallback delete with params.locale removes only that locale record', async () => {
+      test('publish fallback delete removes only the requested locale', async () => {
         const {
           strapi,
           middlewareFn,
@@ -874,7 +879,7 @@ describe('Document Service middleware', () => {
         })
       })
 
-      test('create fallback delete with params.locale removes only that locale record', async () => {
+      test('create fallback delete removes only the requested locale', async () => {
         const {
           strapi,
           middlewareFn,
@@ -911,8 +916,8 @@ describe('Document Service middleware', () => {
       })
     })
 
-    describe('when sync config indexes draft entries across locales', () => {
-      test('delete with params.locale=* removes all draft locale records', async () => {
+    describe('draft-only all-locale index', () => {
+      test('delete with all-locale action removes every draft locale', async () => {
         const strapiLocaleVariants = [
           { documentId: 'doc-15', locale: 'en' },
           { documentId: 'doc-15', locale: 'fr' },
@@ -960,8 +965,8 @@ describe('Document Service middleware', () => {
     })
   })
 
-  describe('draft/publish lifecycle sync behavior', () => {
-    test('unpublish is ignored when sync config indexes drafts', async () => {
+  describe('draft-only and published-only index behavior', () => {
+    test('unpublish does not change Meilisearch when index stores drafts', async () => {
       const {
         strapi,
         middlewareFn,
@@ -987,14 +992,14 @@ describe('Document Service middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discardDraft is ignored when sync config indexes published entries', async () => {
+    test('discardDraft does not change Meilisearch when index stores published entries', async () => {
       const {
         strapi,
         middlewareFn,
         updateEntriesInMeilisearch,
         deleteEntriesFromMeiliSearch,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { status: 'published' },
+        meilisearchEntriesQuery: SYNC_PRESETS.publishedOnly,
       })
 
       await registerDocumentMiddleware({ strapi })
@@ -1013,14 +1018,13 @@ describe('Document Service middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('discardDraft re-indexes only params.locale in draft sync', async () => {
-      const strapiDraftFrenchEntry = {
+    test('discardDraft re-indexes only the requested locale for draft indexes', async () => {
+      const strapiDraftFrenchEntry = createDraftEntry({
         id: 202,
         documentId: 'doc-22',
         locale: 'fr',
-        publishedAt: null,
         title: 'French draft',
-      }
+      })
 
       const {
         strapi,
@@ -1028,7 +1032,7 @@ describe('Document Service middleware', () => {
         updateEntriesInMeilisearch,
         deleteEntriesFromMeiliSearch,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { status: 'draft', locale: 'fr' },
+        meilisearchEntriesQuery: SYNC_PRESETS.draftFrench,
       })
 
       await registerDocumentMiddleware({ strapi })
@@ -1055,21 +1059,19 @@ describe('Document Service middleware', () => {
       })
     })
 
-    test('discardDraft with params.locale=* re-indexes every returned draft locale', async () => {
-      const strapiDraftEnglishEntry = {
+    test('discardDraft with all-locale action re-indexes every returned draft locale', async () => {
+      const strapiDraftEnglishEntry = createDraftEntry({
         id: 203,
         documentId: 'doc-23',
         locale: 'en',
-        publishedAt: null,
         title: 'English draft',
-      }
-      const strapiDraftFrenchEntry = {
+      })
+      const strapiDraftFrenchEntry = createDraftEntry({
         id: 204,
         documentId: 'doc-23',
         locale: 'fr',
-        publishedAt: null,
         title: 'French draft',
-      }
+      })
 
       const {
         strapi,
@@ -1077,7 +1079,7 @@ describe('Document Service middleware', () => {
         updateEntriesInMeilisearch,
         deleteEntriesFromMeiliSearch,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+        meilisearchEntriesQuery: SYNC_PRESETS.draftAllLocales,
       })
 
       await registerDocumentMiddleware({ strapi })
@@ -1105,14 +1107,149 @@ describe('Document Service middleware', () => {
       })
     })
 
-    test('discardDraft re-fetches params.locale when result misses that Strapi document', async () => {
+    test('discardDraft with all-locales action removes stale draft locales from the index', async () => {
+      const strapiDraftEnglishEntry = createDraftEntry({
+        id: 203,
+        documentId: 'doc-70',
+        locale: 'en',
+        title: 'English draft',
+      })
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+        contentTypeGetEntries,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: SYNC_PRESETS.draftAllLocales,
+        contentTypeGetEntries: jest.fn(({ filters, fields }) => {
+          if (filters?.documentId === 'doc-70') {
+            if (Array.isArray(fields)) {
+              return Promise.resolve([
+                { documentId: 'doc-70', locale: 'en' },
+                { documentId: 'doc-70', locale: 'fr' },
+              ])
+            }
+
+            return Promise.resolve([
+              createDraftEntry({
+                id: 703,
+                documentId: 'doc-70',
+                locale: 'en',
+              }),
+              createPublishedEntry({
+                id: 704,
+                documentId: 'doc-70',
+                locale: 'fr',
+              }),
+            ])
+          }
+
+          return Promise.resolve([])
+        }),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-70', locale: '*' },
+      }
+      const result = {
+        documentId: 'doc-70',
+        versions: [
+          strapiDraftEnglishEntry,
+          {
+            id: 204,
+            documentId: 'doc-70',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+          },
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntries).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        fields: ['documentId', 'locale'],
+        locale: '*',
+        status: 'draft',
+        filters: {
+          documentId: 'doc-70',
+        },
+      })
+      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        entries: [
+          expect.objectContaining({ documentId: 'doc-70', locale: 'en' }),
+        ],
+      })
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-70'],
+        entriesQuery: { status: 'draft', locale: '*' },
+        locales: ['fr'],
+      })
+    })
+
+    test('discardDraft removes a locale-scoped draft record when the draft no longer exists', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        updateEntriesInMeilisearch,
+        deleteEntriesFromMeiliSearch,
+        contentTypeGetEntry,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: SYNC_PRESETS.draftFrench,
+        contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'discardDraft',
+        params: { documentId: 'doc-71', locale: 'fr' },
+      }
+      const result = {
+        documentId: 'doc-71',
+        versions: [
+          createPublishedEntry({
+            id: 711,
+            documentId: 'doc-71',
+            locale: 'fr',
+          }),
+        ],
+      }
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntry).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentId: 'doc-71',
+        entriesQuery: { status: 'draft', locale: 'fr' },
+      })
+      expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-71'],
+        entriesQuery: { status: 'draft', locale: 'fr' },
+        locales: undefined,
+      })
+    })
+
+    test('discardDraft loads the requested locale when action result omits the document', async () => {
       const {
         strapi,
         middlewareFn,
         updateEntriesInMeilisearch,
         contentTypeGetEntry,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+        meilisearchEntriesQuery: SYNC_PRESETS.draftAllLocales,
         contentTypeGetEntry: jest.fn(() =>
           Promise.resolve({
             id: 205,
@@ -1152,14 +1289,14 @@ describe('Document Service middleware', () => {
       })
     })
 
-    test('publish does not fan out published locales when sync config indexes drafts', async () => {
+    test('publish does not fan out published locales when index stores drafts', async () => {
       const {
         strapi,
         middlewareFn,
         updateEntriesInMeilisearch,
         contentTypeGetEntry,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { status: 'draft', locale: '*' },
+        meilisearchEntriesQuery: SYNC_PRESETS.draftAllLocales,
         contentTypeGetEntry: jest.fn(() =>
           Promise.resolve({
             id: 206,
@@ -1213,8 +1350,8 @@ describe('Document Service middleware', () => {
     })
   })
 
-  describe('locale=* sync re-fetch behavior', () => {
-    test('create re-fetches the Strapi entry with params.locale when needed', async () => {
+  describe('locale-specific fallback reads for all-locale indexes', () => {
+    test('create loads the requested locale from Strapi when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1252,7 +1389,7 @@ describe('Document Service middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update re-fetches the Strapi entry with params.locale when needed', async () => {
+    test('update loads the requested locale from Strapi when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1295,7 +1432,7 @@ describe('Document Service middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('update uses the params.locale entry from result before re-fetching', async () => {
+    test('update prefers the requested locale from result before reading Strapi', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1340,7 +1477,7 @@ describe('Document Service middleware', () => {
       })
     })
 
-    test('publish re-fetches the Strapi entry with params.locale when needed', async () => {
+    test('publish loads the requested locale from Strapi when needed', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1383,7 +1520,7 @@ describe('Document Service middleware', () => {
       expect(updateEntriesInMeilisearch).toHaveBeenCalled()
     })
 
-    test('locale=* re-fetch keeps sync query options while narrowing to params.locale', async () => {
+    test('locale-scoped fallback read preserves configured sync query options', async () => {
       const configuredSyncQuery = {
         locale: '*',
         status: 'published',
@@ -1437,8 +1574,8 @@ describe('Document Service middleware', () => {
     })
   })
 
-  describe('publish fan-out across locales', () => {
-    test('publish with params.locale=* indexes every returned published locale entry', async () => {
+  describe('publish behavior for all-locale actions', () => {
+    test('publish with all-locale action indexes every returned published locale', async () => {
       const strapiPublishedEnglishEntry = {
         id: 401,
         documentId: 'doc-40',
@@ -1480,7 +1617,7 @@ describe('Document Service middleware', () => {
       })
     })
 
-    test('publish with params.locale=* and concrete sync locale indexes only owned locale', async () => {
+    test('publish with all-locale action and concrete sync locale indexes only owned locale', async () => {
       const strapiPublishedEnglishEntry = {
         id: 411,
         documentId: 'doc-41',
@@ -1500,7 +1637,7 @@ describe('Document Service middleware', () => {
         updateEntriesInMeilisearch,
         deleteEntriesFromMeiliSearch,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: 'fr' },
+        meilisearchEntriesQuery: SYNC_PRESETS.frenchOnly,
       })
 
       await registerDocumentMiddleware({ strapi })
@@ -1525,7 +1662,7 @@ describe('Document Service middleware', () => {
       expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
 
-    test('publish with params.locale=* deletes stale owned locale when publish result has no owned locale', async () => {
+    test('publish with all-locale action removes stale owned locale when result omits it', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1533,7 +1670,7 @@ describe('Document Service middleware', () => {
         deleteEntriesFromMeiliSearch,
         contentTypeGetEntry,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: 'fr' },
+        meilisearchEntriesQuery: SYNC_PRESETS.frenchOnly,
         contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
       })
 
@@ -1570,6 +1707,96 @@ describe('Document Service middleware', () => {
         documentIds: ['doc-42'],
         entriesQuery: { locale: 'fr' },
         locales: undefined,
+      })
+    })
+  })
+
+  describe('bulk removal actions', () => {
+    test('deleteMany removes all deleted documents from Meilisearch', async () => {
+      const { strapi, middlewareFn, deleteEntriesFromMeiliSearch } =
+        createStrapiStubs()
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'deleteMany',
+        params: { documentIds: ['doc-a', 'doc-b'] },
+      }
+      const result = [{ documentId: 'doc-a' }, { documentId: 'doc-b' }]
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        documentIds: ['doc-a', 'doc-b'],
+        entriesQuery: {},
+      })
+    })
+
+    test('deleteMany with all-locales action removes locale variants per deleted document', async () => {
+      const {
+        strapi,
+        middlewareFn,
+        deleteEntriesFromMeiliSearch,
+        contentTypeGetEntries,
+      } = createStrapiStubs({
+        meilisearchEntriesQuery: { locale: '*' },
+        contentTypeGetEntries: jest.fn(({ filters }) => {
+          if (filters?.documentId === 'doc-a') {
+            return Promise.resolve([
+              { documentId: 'doc-a', locale: 'en' },
+              { documentId: 'doc-a', locale: 'fr' },
+            ])
+          }
+          if (filters?.documentId === 'doc-b') {
+            return Promise.resolve([{ documentId: 'doc-b', locale: 'en' }])
+          }
+
+          return Promise.resolve([])
+        }),
+      })
+
+      await registerDocumentMiddleware({ strapi })
+
+      const handler = middlewareFn()
+      const ctx = {
+        uid: 'api::restaurant.restaurant',
+        action: 'deleteMany',
+        params: { documentIds: ['doc-a', 'doc-b'], locale: '*' },
+      }
+      const result = [{ documentId: 'doc-a' }, { documentId: 'doc-b' }]
+
+      await handler(ctx, () => Promise.resolve(result))
+
+      expect(contentTypeGetEntries).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        fields: ['documentId', 'locale'],
+        locale: '*',
+        filters: {
+          documentId: 'doc-a',
+        },
+      })
+      expect(contentTypeGetEntries).toHaveBeenCalledWith({
+        contentType: ctx.uid,
+        fields: ['documentId', 'locale'],
+        locale: '*',
+        filters: {
+          documentId: 'doc-b',
+        },
+      })
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenNthCalledWith(1, {
+        contentType: ctx.uid,
+        documentIds: ['doc-a'],
+        entriesQuery: { locale: '*' },
+        locales: ['en', 'fr'],
+      })
+      expect(deleteEntriesFromMeiliSearch).toHaveBeenNthCalledWith(2, {
+        contentType: ctx.uid,
+        documentIds: ['doc-b'],
+        entriesQuery: { locale: '*' },
+        locales: ['en'],
       })
     })
   })

--- a/server/src/__tests__/meilisearch.test.js
+++ b/server/src/__tests__/meilisearch.test.js
@@ -11,7 +11,7 @@ const strapiMock = createStrapiMock({})
 // @ts-ignore
 global.strapi = strapiMock
 
-describe('Tests content types', () => {
+describe('Meilisearch service behavior', () => {
   beforeEach(async () => {
     jest.clearAllMocks()
     jest.restoreAllMocks()
@@ -334,7 +334,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('deletes only configured locale variant when entriesQuery.locale is set', async () => {
+  test('deletes only the configured locale variant', async () => {
     const client = new Meilisearch({ host: 'abc' })
     const { meilisearchService } = createLocaleMeilisearchContext({
       entriesQuery: { locale: 'fr' },
@@ -351,7 +351,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('deletes every locale variant when wildcard locale configured', async () => {
+  test('deletes every locale variant for all-locale indexes', async () => {
     const getEntriesMock = jest.fn(() => [
       { documentId: 'doc-1', locale: 'en' },
       { documentId: 'doc-1', locale: 'fr' },
@@ -416,7 +416,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('deletes base document when wildcard locale has no localized entries', async () => {
+  test('deletes base document when no localized entries exist', async () => {
     const getEntriesMock = jest.fn(async () => [])
 
     const client = new Meilisearch({ host: 'abc' })
@@ -444,7 +444,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('deletes every locale variant when entriesQuery locale is all', async () => {
+  test('treats entriesQuery locale=all as all-locale deletion', async () => {
     const entriesFetcher = jest.fn(() => [
       { documentId: 'doc-1', locale: 'en' },
       { documentId: 'doc-1', locale: 'fr' },
@@ -477,7 +477,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('wildcard locale lookup forwards configured status to getEntries', async () => {
+  test('all-locale lookups keep the configured status filter', async () => {
     const getEntriesMock = jest.fn(() => [
       { documentId: 'doc-1', locale: 'en' },
       { documentId: 'doc-1', locale: 'fr' },
@@ -510,7 +510,7 @@ describe('Tests content types', () => {
     ])
   })
 
-  test('deleteEntriesFromMeiliSearch uses provided locales instead of querying entries', async () => {
+  test('uses provided locales instead of querying Strapi locales', async () => {
     const getEntriesMock = jest.fn(() => {
       throw new Error(
         'getEntries should not be called when locales are provided',

--- a/server/src/__tests__/utils/document-middleware-fixtures.js
+++ b/server/src/__tests__/utils/document-middleware-fixtures.js
@@ -1,0 +1,49 @@
+/**
+ * Reusable sync query presets for document middleware tests.
+ */
+export const SYNC_PRESETS = {
+  default: {},
+  allLocales: { locale: '*' },
+  draftAllLocales: { status: 'draft', locale: '*' },
+  draftFrench: { status: 'draft', locale: 'fr' },
+  publishedOnly: { status: 'published' },
+  frenchOnly: { locale: 'fr' },
+}
+
+/**
+ * Build a minimal draft Strapi entry fixture.
+ *
+ * @param {object} options - Draft entry options.
+ * @param {number} options.id - Database id.
+ * @param {string} options.documentId - Strapi document id.
+ * @param {string} options.locale - Locale code.
+ * @param {string} [options.title] - Optional title.
+ *
+ * @returns {{id:number, documentId:string, locale:string, publishedAt:null, title?:string}}
+ */
+export const createDraftEntry = ({ id, documentId, locale, title }) => ({
+  id,
+  documentId,
+  locale,
+  publishedAt: null,
+  ...(title ? { title } : {}),
+})
+
+/**
+ * Build a minimal published Strapi entry fixture.
+ *
+ * @param {object} options - Published entry options.
+ * @param {number} options.id - Database id.
+ * @param {string} options.documentId - Strapi document id.
+ * @param {string} options.locale - Locale code.
+ * @param {string} [options.title] - Optional title.
+ *
+ * @returns {{id:number, documentId:string, locale:string, publishedAt:string, title?:string}}
+ */
+export const createPublishedEntry = ({ id, documentId, locale, title }) => ({
+  id,
+  documentId,
+  locale,
+  publishedAt: '2024-01-01',
+  ...(title ? { title } : {}),
+})

--- a/server/src/services/document-middleware/document-ids.js
+++ b/server/src/services/document-middleware/document-ids.js
@@ -1,0 +1,63 @@
+/**
+ * Resolve document ids passed directly in action params.
+ *
+ * @param {object|null|undefined} actionParams - Document service action params.
+ *
+ * @returns {string[]} Unique document ids found in params.
+ */
+export const resolveDocumentIdsFromActionParams = actionParams => {
+  const explicitDocumentIds = Array.isArray(actionParams?.documentIds)
+    ? actionParams.documentIds.filter(
+        documentId => typeof documentId === 'string' && documentId.length > 0,
+      )
+    : []
+
+  const singleDocumentId =
+    typeof actionParams?.documentId === 'string' &&
+    actionParams.documentId.length > 0
+      ? [actionParams.documentId]
+      : []
+
+  return [...new Set([...explicitDocumentIds, ...singleDocumentId])]
+}
+
+/**
+ * Resolve document ids from action params, middleware result, and pre-action snapshots.
+ *
+ * @param {object} options - Document id resolution options.
+ * @param {object|null|undefined} options.actionParams - Document service action params.
+ * @param {object|object[]|null|undefined} options.result - Result returned by document service.
+ * @param {{documentId: string}[]|null|undefined} options.preActionSnapshots - Pre-action snapshots keyed by document id.
+ *
+ * @returns {string[]} Unique document ids.
+ */
+export const resolveDocumentIds = ({
+  actionParams,
+  result,
+  preActionSnapshots,
+}) => {
+  const ids = [...resolveDocumentIdsFromActionParams(actionParams)]
+
+  const appendDocumentId = documentId => {
+    if (typeof documentId === 'string' && documentId.length > 0) {
+      ids.push(documentId)
+    }
+  }
+
+  const inspectCandidate = candidate => {
+    if (!candidate || typeof candidate !== 'object') return
+    appendDocumentId(candidate.documentId)
+  }
+
+  if (Array.isArray(result)) {
+    result.forEach(inspectCandidate)
+  } else {
+    inspectCandidate(result)
+  }
+
+  ;(preActionSnapshots || []).forEach(snapshot =>
+    appendDocumentId(snapshot?.documentId),
+  )
+
+  return [...new Set(ids)]
+}

--- a/server/src/services/document-middleware/entry-candidates.js
+++ b/server/src/services/document-middleware/entry-candidates.js
@@ -1,0 +1,75 @@
+/**
+ * Convert document service results into Strapi entry candidates with source metadata.
+ *
+ * @param {object|object[]|null|undefined} result - Value returned by document service.
+ *
+ * @returns {{data: object, source: string}[]} Flat list of potential Strapi entry candidates.
+ */
+export const extractStrapiEntryCandidates = result => {
+  if (result == null) return []
+
+  const candidates = []
+  const appendCandidate = (data, source) => {
+    if (data != null && typeof data === 'object') {
+      candidates.push({ data, source })
+    }
+  }
+
+  if (Array.isArray(result)) {
+    result.forEach(data => appendCandidate(data, 'root'))
+    return candidates
+  }
+
+  appendCandidate(result, 'root')
+
+  if (Array.isArray(result.versions)) {
+    result.versions.forEach(data => appendCandidate(data, 'versions'))
+  }
+
+  if (Array.isArray(result.entries)) {
+    result.entries.forEach(data => appendCandidate(data, 'entries'))
+  }
+
+  if (result.entry != null) {
+    appendCandidate(result.entry, 'entry')
+  }
+
+  return candidates
+}
+
+/**
+ * Determine whether a Strapi entry represents a published version.
+ *
+ * @param {object} entry - Strapi entry candidate.
+ *
+ * @returns {boolean} True when `publishedAt` is set.
+ */
+export const isPublishedStrapiEntry = entry =>
+  !(entry?.publishedAt === undefined || entry?.publishedAt === null)
+
+/**
+ * Rank Strapi entry candidates by entry-likeness so nested entries beat root wrappers.
+ * Rule 1: Real DB entries (has 'id' primary key) beat wrappers (no 'id').
+ * Rule 2: Nested sources ('versions', 'entries') beat the 'root' source.
+ *
+ * @param {{data: object, source: string}[]} candidates - Candidates matching one Strapi document id.
+ *
+ * @returns {{data: object, source: string}[]} Ranked Strapi entry candidates.
+ */
+export const rankStrapiEntryCandidates = candidates => {
+  return [...candidates].sort((a, b) => {
+    const aHasPrimaryKey = a.data?.id != null
+    const bHasPrimaryKey = b.data?.id != null
+
+    if (aHasPrimaryKey && !bHasPrimaryKey) return -1
+    if (!aHasPrimaryKey && bHasPrimaryKey) return 1
+
+    const aIsRoot = a.source === 'root'
+    const bIsRoot = b.source === 'root'
+
+    if (!aIsRoot && bIsRoot) return -1
+    if (aIsRoot && !bIsRoot) return 1
+
+    return 0
+  })
+}

--- a/server/src/services/document-middleware/entry-selection.js
+++ b/server/src/services/document-middleware/entry-selection.js
@@ -1,0 +1,191 @@
+import {
+  isPublishedStrapiEntry,
+  rankStrapiEntryCandidates,
+} from './entry-candidates.js'
+import {
+  getActionLocale,
+  resolvePreferredConcreteLocale,
+} from './locale-resolution.js'
+import { isWildcardLocale } from '../meilisearch/config'
+
+/**
+ * Pick the Strapi entry to index for update-like Strapi document actions.
+ *
+ * @param {object} options - Entry selection options.
+ * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object} options.syncQuery - Plugin sync query configuration.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ *
+ * @returns {object|null} Selected Strapi entry to index, if any.
+ */
+export const selectStrapiEntryToIndexFromResult = ({
+  resultCandidates,
+  documentId,
+  syncQuery,
+  actionParams,
+}) => {
+  const strapiDocumentEntryCandidates = (resultCandidates || []).filter(
+    candidate => candidate?.data?.documentId === documentId,
+  )
+  if (strapiDocumentEntryCandidates.length === 0) return null
+
+  const rankedEntryCandidates = rankStrapiEntryCandidates(
+    strapiDocumentEntryCandidates,
+  )
+  const preferredConcreteLocale = resolvePreferredConcreteLocale({
+    syncQuery,
+    actionParams,
+  })
+  const localeScopedEntryCandidate = preferredConcreteLocale
+    ? rankedEntryCandidates.find(
+        candidate => candidate?.data?.locale === preferredConcreteLocale,
+      )
+    : null
+
+  if (syncQuery?.status === 'draft') {
+    const isIndexableDraftEntryCandidate = candidate =>
+      candidate?.data?.id != null && !isPublishedStrapiEntry(candidate.data)
+    if (preferredConcreteLocale) {
+      return localeScopedEntryCandidate &&
+        isIndexableDraftEntryCandidate(localeScopedEntryCandidate)
+        ? localeScopedEntryCandidate.data
+        : null
+    }
+
+    const draftEntryCandidate = rankedEntryCandidates.find(
+      isIndexableDraftEntryCandidate,
+    )
+    return draftEntryCandidate?.data || null
+  }
+
+  if (preferredConcreteLocale) {
+    return localeScopedEntryCandidate &&
+      isPublishedStrapiEntry(localeScopedEntryCandidate.data)
+      ? localeScopedEntryCandidate.data
+      : null
+  }
+
+  const publishedEntryCandidate = rankedEntryCandidates.find(candidate =>
+    isPublishedStrapiEntry(candidate.data),
+  )
+
+  return publishedEntryCandidate?.data || null
+}
+
+/**
+ * Resolve draft Strapi entries to index for `discardDraft` in draft-only indexes.
+ *
+ * @param {object} options - Draft selection options.
+ * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ *
+ * @returns {object[]} Draft Strapi entries scoped to the requested action locale.
+ */
+export const selectDraftEntriesForDiscardDraftResult = ({
+  resultCandidates,
+  documentId,
+  actionParams,
+}) => {
+  const actionLocale = getActionLocale(actionParams)
+  const rankedDraftEntryCandidates = rankStrapiEntryCandidates(
+    (resultCandidates || []).filter(
+      candidate =>
+        candidate?.data?.documentId === documentId &&
+        !isPublishedStrapiEntry(candidate.data),
+    ),
+  )
+  const rankedLocalizedDraftEntryCandidates = rankedDraftEntryCandidates.filter(
+    candidate =>
+      typeof candidate?.data?.locale === 'string' &&
+      candidate.data.locale.length > 0,
+  )
+
+  if (rankedDraftEntryCandidates.length === 0) return []
+
+  if (actionLocale && !isWildcardLocale(actionLocale)) {
+    const localeCandidate = rankedLocalizedDraftEntryCandidates.find(
+      candidate => candidate?.data?.locale === actionLocale,
+    )
+    return localeCandidate ? [localeCandidate.data] : []
+  }
+
+  if (actionLocale && isWildcardLocale(actionLocale)) {
+    const entriesByLocale = new Map()
+    rankedLocalizedDraftEntryCandidates.forEach(candidate => {
+      const locale = candidate.data.locale
+      if (!entriesByLocale.has(locale)) {
+        entriesByLocale.set(locale, candidate.data)
+      }
+    })
+    return [...entriesByLocale.values()]
+  }
+
+  return [
+    rankedLocalizedDraftEntryCandidates[0]?.data ||
+      rankedDraftEntryCandidates[0].data,
+  ]
+}
+
+/**
+ * Resolve published Strapi entries when wildcard action locale returns multiple versions.
+ *
+ * @param {object} options - Wildcard publish options.
+ * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
+ *
+ * @returns {object[]} Published Strapi entries keyed by locale/id for wildcard publish actions.
+ */
+export const selectPublishedEntriesForWildcardPublish = ({
+  resultCandidates,
+  documentId,
+  actionParams,
+  syncQuery,
+}) => {
+  const actionLocale = getActionLocale(actionParams)
+  const syncLocale = syncQuery?.locale
+  const syncStatusScope = syncQuery?.status
+  const syncAllowsPublishedEntries =
+    syncStatusScope == null || syncStatusScope !== 'draft'
+  if (
+    !actionLocale ||
+    !isWildcardLocale(actionLocale) ||
+    !isWildcardLocale(syncLocale) ||
+    !syncAllowsPublishedEntries
+  ) {
+    return []
+  }
+
+  const rankedPublishedEntryCandidates = rankStrapiEntryCandidates(
+    (resultCandidates || []).filter(
+      candidate =>
+        candidate?.data?.documentId === documentId &&
+        isPublishedStrapiEntry(candidate.data),
+    ),
+  )
+  if (rankedPublishedEntryCandidates.length === 0) return []
+
+  const selectedEntries = []
+  const seenKeys = new Set()
+
+  rankedPublishedEntryCandidates.forEach(candidate => {
+    const strapiEntry = candidate?.data
+    if (!strapiEntry || typeof strapiEntry !== 'object') return
+
+    const localeKey =
+      typeof strapiEntry.locale === 'string' && strapiEntry.locale.length > 0
+        ? `locale:${strapiEntry.locale}`
+        : null
+    const idKey = strapiEntry.id != null ? `id:${strapiEntry.id}` : null
+    const dedupeKey = localeKey || idKey
+
+    if (!dedupeKey || seenKeys.has(dedupeKey)) return
+    seenKeys.add(dedupeKey)
+    selectedEntries.push(strapiEntry)
+  })
+
+  return selectedEntries
+}

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -6,13 +6,13 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Convert document service results into entry candidates with source metadata.
+   * Convert document service results into Strapi row candidates with source metadata.
    *
    * @param {object|object[]|null|undefined} result - Value returned by document service.
    *
-   * @returns {{data: object, source: string}[]} Flat list of potential entry candidates.
+   * @returns {{data: object, source: string}[]} Flat list of potential Strapi row candidates.
    */
-  const extractEntryCandidates = result => {
+  const extractStrapiRowCandidates = result => {
     if (result == null) return []
 
     const candidates = []
@@ -45,25 +45,25 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Determine whether an entry represents a published version.
+   * Determine whether a Strapi row represents a published version.
    *
-   * @param {object} entry - Entry candidate.
+   * @param {object} entry - Strapi row candidate.
    *
    * @returns {boolean} True when `publishedAt` is set.
    */
-  const isPublishedEntry = entry =>
+  const isPublishedStrapiRow = entry =>
     !(entry?.publishedAt === undefined || entry?.publishedAt === null)
 
   /**
-   * Rank candidates by entry-likeness so nested rows beat root wrappers.
+   * Rank Strapi row candidates by row-likeness so nested rows beat root wrappers.
    * Rule 1: Real DB rows (has 'id' primary key) beat wrappers (no 'id').
    * Rule 2: Nested sources ('versions', 'entries') beat the 'root' source.
    *
-   * @param {{data: object, source: string}[]} candidates - Candidates matching one documentId.
+   * @param {{data: object, source: string}[]} candidates - Candidates matching one Strapi document id.
    *
-   * @returns {{data: object, source: string}[]} Ranked candidates.
+   * @returns {{data: object, source: string}[]} Ranked Strapi row candidates.
    */
-  const rankEntryCandidates = candidates => {
+  const rankStrapiRowCandidates = candidates => {
     return [...candidates].sort((a, b) => {
       const aHasPrimaryKey = a.data?.id != null
       const bHasPrimaryKey = b.data?.id != null
@@ -82,81 +82,86 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Pick the entry to index for update-like document actions.
+   * Pick the Strapi row to index for update-like Strapi document actions.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
-   * @param {string} options.documentId - Target document id.
-   * @param {object} options.entriesQuery - Plugin entries query configuration.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {string} options.documentId - Target Strapi document id.
+   * @param {object} options.syncQuery - Plugin sync query configuration.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
-   * @returns {object|null} Selected entry to index, if any.
+   * @returns {object|null} Selected Strapi row to index, if any.
    */
-  const getEntryFromResult = ({
+  const selectStrapiRowToIndexFromResult = ({
     resultCandidates,
     documentId,
-    entriesQuery,
+    syncQuery,
     actionParams,
   }) => {
-    const documentCandidates = (resultCandidates || []).filter(
+    const strapiDocumentRowCandidates = (resultCandidates || []).filter(
       candidate => candidate?.data?.documentId === documentId,
     )
-    if (documentCandidates.length === 0) return null
+    if (strapiDocumentRowCandidates.length === 0) return null
 
-    const rankedCandidates = rankEntryCandidates(documentCandidates)
+    const rankedRowCandidates = rankStrapiRowCandidates(
+      strapiDocumentRowCandidates,
+    )
     const actionLocale = getActionLocale(actionParams)
-    const localeScopedCandidate =
+    const localeScopedRowCandidate =
       actionLocale && !isWildcardLocale(actionLocale)
-        ? rankedCandidates.find(
+        ? rankedRowCandidates.find(
             candidate => candidate?.data?.locale === actionLocale,
           )
         : null
 
-    if (entriesQuery?.status === 'draft') {
-      const isIndexableDraftCandidate = candidate =>
-        candidate?.data?.id != null && !isPublishedEntry(candidate.data)
-      const draftCandidate =
-        localeScopedCandidate &&
-        isIndexableDraftCandidate(localeScopedCandidate)
-          ? localeScopedCandidate
-          : rankedCandidates.find(isIndexableDraftCandidate)
-      return draftCandidate?.data || null
+    if (syncQuery?.status === 'draft') {
+      const isIndexableDraftRowCandidate = candidate =>
+        candidate?.data?.id != null && !isPublishedStrapiRow(candidate.data)
+      const draftRowCandidate =
+        localeScopedRowCandidate &&
+        isIndexableDraftRowCandidate(localeScopedRowCandidate)
+          ? localeScopedRowCandidate
+          : rankedRowCandidates.find(isIndexableDraftRowCandidate)
+      return draftRowCandidate?.data || null
     }
 
-    const publishedCandidate =
-      localeScopedCandidate && isPublishedEntry(localeScopedCandidate.data)
-        ? localeScopedCandidate
-        : rankedCandidates.find(candidate => isPublishedEntry(candidate.data))
+    const publishedRowCandidate =
+      localeScopedRowCandidate &&
+      isPublishedStrapiRow(localeScopedRowCandidate.data)
+        ? localeScopedRowCandidate
+        : rankedRowCandidates.find(candidate =>
+            isPublishedStrapiRow(candidate.data),
+          )
 
-    return publishedCandidate?.data || null
+    return publishedRowCandidate?.data || null
   }
 
   /**
-   * Fetch an entry on the next event-loop turn to avoid leaking finished transactions.
+   * Fetch a Strapi row on the next event-loop turn to avoid leaking finished transactions.
    *
    * @param {object} options
    * @param {object} options.contentTypeService - Plugin content type service.
    * @param {string} options.contentType - Content type uid.
-   * @param {string} options.documentId - Target document id.
-   * @param {object} options.entriesQuery - Query used to fetch the indexable entry.
+   * @param {string} options.documentId - Target Strapi document id.
+   * @param {object} options.syncQuery - Query used to fetch the indexable Strapi row.
    *
-   * @returns {Promise<object|null>} Entry to index or null.
+   * @returns {Promise<object|null>} Strapi row to index or null.
    */
-  const getEntryOutsideTransaction = ({
+  const getStrapiRowAfterTransaction = ({
     contentTypeService,
     contentType,
     documentId,
-    entriesQuery,
+    syncQuery,
   }) =>
     new Promise((resolve, reject) => {
       setImmediate(async () => {
         try {
-          const entry = await contentTypeService.getEntry({
+          const strapiRow = await contentTypeService.getEntry({
             contentType,
             documentId,
-            entriesQuery: { ...entriesQuery },
+            entriesQuery: { ...syncQuery },
           })
-          resolve(entry)
+          resolve(strapiRow)
         } catch (error) {
           reject(error)
         }
@@ -178,20 +183,20 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Build the fallback query used by `getEntry` for update-like actions.
+   * Build the locale-scoped query used by `getEntry` for update-like actions.
    *
    * When index config targets all locales (`*`) but the action is locale-scoped,
    * keep every existing query option and only override `locale` with the action locale.
    *
    * @param {object} options
-   * @param {object|null|undefined} options.entriesQuery - Base query from Meilisearch config.
+   * @param {object|null|undefined} options.syncQuery - Base query from Meilisearch config.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
    * @returns {object} Query passed to `contentTypeService.getEntry`.
    */
-  const resolveFallbackEntriesQuery = ({ entriesQuery, actionParams }) => {
+  const resolveLocaleScopedReadQuery = ({ syncQuery, actionParams }) => {
     const actionLocale = getActionLocale(actionParams)
-    const baseQuery = { ...(entriesQuery || {}) }
+    const baseQuery = { ...(syncQuery || {}) }
 
     if (!isWildcardLocale(baseQuery.locale) || actionLocale == null) {
       return baseQuery
@@ -208,14 +213,14 @@ export default async function registerDocumentMiddleware({ strapi }) {
    *
    * @param {object} options
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {object|null} options.preDeleteEntry - Entry fetched before running the delete-like action.
+   * @param {object|null} options.preDeleteStrapiRow - Row fetched before running the delete-like action.
    * @param {object[]|null|undefined} options.localeVariants - Locale variants fetched for wildcard action locales.
    *
    * @returns {string[]} Locales to remove from Meilisearch.
    */
-  const resolveDeleteLocales = ({
+  const resolveLocaleCodesToRemoveFromIndex = ({
     actionParams,
-    preDeleteEntry,
+    preDeleteStrapiRow,
     localeVariants,
   }) => {
     const actionLocale = getActionLocale(actionParams)
@@ -225,9 +230,9 @@ export default async function registerDocumentMiddleware({ strapi }) {
     }
 
     if (actionLocale == null) {
-      return typeof preDeleteEntry?.locale === 'string' &&
-        preDeleteEntry.locale.length > 0
-        ? [preDeleteEntry.locale]
+      return typeof preDeleteStrapiRow?.locale === 'string' &&
+        preDeleteStrapiRow.locale.length > 0
+        ? [preDeleteStrapiRow.locale]
         : []
     }
 
@@ -241,38 +246,38 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Resolve draft entries to index for `discardDraft` in draft-only indexes.
+   * Resolve draft Strapi rows to index for `discardDraft` in draft-only indexes.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
-   * @param {string} options.documentId - Target document id.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {string} options.documentId - Target Strapi document id.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
-   * @returns {object[]} Draft entries scoped to the requested action locale.
+   * @returns {object[]} Draft Strapi rows scoped to the requested action locale.
    */
-  const getDiscardDraftEntriesFromResult = ({
+  const selectDraftRowsForDiscardDraftResult = ({
     resultCandidates,
     documentId,
     actionParams,
   }) => {
     const actionLocale = getActionLocale(actionParams)
-    const rankedDraftCandidates = rankEntryCandidates(
+    const rankedDraftRowCandidates = rankStrapiRowCandidates(
       (resultCandidates || []).filter(
         candidate =>
           candidate?.data?.documentId === documentId &&
-          !isPublishedEntry(candidate.data),
+          !isPublishedStrapiRow(candidate.data),
       ),
     )
-    const rankedLocalizedDraftCandidates = rankedDraftCandidates.filter(
+    const rankedLocalizedDraftRowCandidates = rankedDraftRowCandidates.filter(
       candidate =>
         typeof candidate?.data?.locale === 'string' &&
         candidate.data.locale.length > 0,
     )
 
-    if (rankedDraftCandidates.length === 0) return []
+    if (rankedDraftRowCandidates.length === 0) return []
 
     if (actionLocale && !isWildcardLocale(actionLocale)) {
-      const localeCandidate = rankedLocalizedDraftCandidates.find(
+      const localeCandidate = rankedLocalizedDraftRowCandidates.find(
         candidate => candidate?.data?.locale === actionLocale,
       )
       return localeCandidate ? [localeCandidate.data] : []
@@ -280,7 +285,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
 
     if (actionLocale && isWildcardLocale(actionLocale)) {
       const entriesByLocale = new Map()
-      rankedLocalizedDraftCandidates.forEach(candidate => {
+      rankedLocalizedDraftRowCandidates.forEach(candidate => {
         const locale = candidate.data.locale
         if (!entriesByLocale.has(locale)) {
           entriesByLocale.set(locale, candidate.data)
@@ -290,68 +295,69 @@ export default async function registerDocumentMiddleware({ strapi }) {
     }
 
     return [
-      rankedLocalizedDraftCandidates[0]?.data || rankedDraftCandidates[0].data,
+      rankedLocalizedDraftRowCandidates[0]?.data ||
+        rankedDraftRowCandidates[0].data,
     ]
   }
 
   /**
-   * Resolve publish entries when wildcard action locale returns multiple versions.
+   * Resolve published Strapi rows when wildcard action locale returns multiple versions.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
-   * @param {string} options.documentId - Target document id.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {string} options.documentId - Target Strapi document id.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {object|null|undefined} options.entriesQuery - Plugin entries query configuration.
+   * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
    *
-   * @returns {object[]} Published entries keyed by locale/id for wildcard publish actions.
+   * @returns {object[]} Published Strapi rows keyed by locale/id for wildcard publish actions.
    */
-  const getPublishEntriesFromResult = ({
+  const selectPublishedRowsForWildcardPublish = ({
     resultCandidates,
     documentId,
     actionParams,
-    entriesQuery,
+    syncQuery,
   }) => {
     const actionLocale = getActionLocale(actionParams)
-    const statusScope = entriesQuery?.status
-    const allowsPublishedEntries =
-      statusScope == null || statusScope !== 'draft'
+    const syncStatusScope = syncQuery?.status
+    const syncAllowsPublishedRows =
+      syncStatusScope == null || syncStatusScope !== 'draft'
     if (
       !actionLocale ||
       !isWildcardLocale(actionLocale) ||
-      !allowsPublishedEntries
+      !syncAllowsPublishedRows
     ) {
       return []
     }
 
-    const rankedPublishedCandidates = rankEntryCandidates(
+    const rankedPublishedRowCandidates = rankStrapiRowCandidates(
       (resultCandidates || []).filter(
         candidate =>
           candidate?.data?.documentId === documentId &&
-          isPublishedEntry(candidate.data),
+          isPublishedStrapiRow(candidate.data),
       ),
     )
-    if (rankedPublishedCandidates.length === 0) return []
+    if (rankedPublishedRowCandidates.length === 0) return []
 
-    const selectedEntries = []
+    const selectedRows = []
     const seenKeys = new Set()
 
-    rankedPublishedCandidates.forEach(candidate => {
-      const entry = candidate?.data
-      if (!entry || typeof entry !== 'object') return
+    rankedPublishedRowCandidates.forEach(candidate => {
+      const strapiRow = candidate?.data
+      if (!strapiRow || typeof strapiRow !== 'object') return
 
       const localeKey =
-        typeof entry.locale === 'string' && entry.locale.length > 0
-          ? `locale:${entry.locale}`
+        typeof strapiRow.locale === 'string' && strapiRow.locale.length > 0
+          ? `locale:${strapiRow.locale}`
           : null
-      const idKey = entry.id != null ? `id:${entry.id}` : null
+      const idKey = strapiRow.id != null ? `id:${strapiRow.id}` : null
       const dedupeKey = localeKey || idKey
 
       if (!dedupeKey || seenKeys.has(dedupeKey)) return
       seenKeys.add(dedupeKey)
-      selectedEntries.push(entry)
+      selectedRows.push(strapiRow)
     })
 
-    return selectedEntries
+    return selectedRows
   }
 
   // Hook document service (only when available) to mirror Strapi creates into Meilisearch.
@@ -379,9 +385,9 @@ export default async function registerDocumentMiddleware({ strapi }) {
         'discardDraft',
       ]
 
-      const entriesQuery = meilisearch.entriesQuery({ contentType })
-      const shouldDeleteByLocale = isWildcardLocale(entriesQuery.locale)
-      const { status } = entriesQuery || {}
+      const syncQuery = meilisearch.entriesQuery({ contentType })
+      const indexSyncUsesWildcardLocale = isWildcardLocale(syncQuery.locale)
+      const { status } = syncQuery || {}
       const statusFilter =
         typeof status === 'string' && status.length > 0 ? { status } : {}
       const isDraftIndex = status === 'draft'
@@ -402,17 +408,17 @@ export default async function registerDocumentMiddleware({ strapi }) {
         shouldTreatAsDeleteAction && ctx?.params?.documentId
           ? ctx.params.documentId
           : null
-      let preDeleteEntry = null
-      let preDeleteLocales = []
+      let preDeleteStrapiRow = null
+      let localeCodesToRemove = []
 
       if (preDeleteDocumentId != null) {
-        preDeleteEntry = await contentTypeService.getEntry({
+        preDeleteStrapiRow = await contentTypeService.getEntry({
           contentType,
           documentId: preDeleteDocumentId,
           entriesQuery: { ...statusFilter },
         })
 
-        if (shouldDeleteByLocale) {
+        if (indexSyncUsesWildcardLocale) {
           const shouldFetchLocaleVariants = isWildcardLocale(
             ctx?.params?.locale,
           )
@@ -428,9 +434,9 @@ export default async function registerDocumentMiddleware({ strapi }) {
               })
             : []
 
-          preDeleteLocales = resolveDeleteLocales({
+          localeCodesToRemove = resolveLocaleCodesToRemoveFromIndex({
             actionParams: ctx?.params,
-            preDeleteEntry,
+            preDeleteStrapiRow,
             localeVariants,
           })
         }
@@ -447,67 +453,68 @@ export default async function registerDocumentMiddleware({ strapi }) {
       const documentId =
         contextDocumentId ??
         result?.documentId ??
-        preDeleteEntry?.documentId ??
+        preDeleteStrapiRow?.documentId ??
         preDeleteDocumentId ??
         null
 
       if (shouldTreatAsUpdateAction && documentId != null) {
-        const resultCandidates = extractEntryCandidates(result)
+        const resultCandidates = extractStrapiRowCandidates(result)
         let entriesToUpdate = []
 
         if (ctx.action === 'discardDraft' && isDraftIndex) {
-          entriesToUpdate = getDiscardDraftEntriesFromResult({
+          entriesToUpdate = selectDraftRowsForDiscardDraftResult({
             resultCandidates,
             documentId,
             actionParams: ctx?.params,
           })
 
           if (entriesToUpdate.length === 0) {
-            const fallbackEntry = await getEntryOutsideTransaction({
+            const fallbackStrapiRow = await getStrapiRowAfterTransaction({
               contentTypeService,
               contentType,
               documentId,
-              entriesQuery: resolveFallbackEntriesQuery({
-                entriesQuery,
+              syncQuery: resolveLocaleScopedReadQuery({
+                syncQuery,
                 actionParams: ctx?.params,
               }),
             })
-            if (fallbackEntry && !isPublishedEntry(fallbackEntry)) {
-              entriesToUpdate = [fallbackEntry]
+            if (fallbackStrapiRow && !isPublishedStrapiRow(fallbackStrapiRow)) {
+              entriesToUpdate = [fallbackStrapiRow]
             }
           }
         } else {
-          const publishResultEntries = getPublishEntriesFromResult({
-            resultCandidates,
-            documentId,
-            actionParams: ctx?.params,
-            entriesQuery,
-          })
-          if (publishResultEntries.length > 0) {
-            entriesToUpdate = publishResultEntries
+          const publishedRowsFromWildcardPublish =
+            selectPublishedRowsForWildcardPublish({
+              resultCandidates,
+              documentId,
+              actionParams: ctx?.params,
+              syncQuery,
+            })
+          if (publishedRowsFromWildcardPublish.length > 0) {
+            entriesToUpdate = publishedRowsFromWildcardPublish
           }
 
-          let entry = getEntryFromResult({
+          let strapiRow = selectStrapiRowToIndexFromResult({
             resultCandidates,
             documentId,
-            entriesQuery,
+            syncQuery,
             actionParams: ctx?.params,
           })
 
-          if (entriesToUpdate.length === 0 && !entry) {
-            entry = await getEntryOutsideTransaction({
+          if (entriesToUpdate.length === 0 && !strapiRow) {
+            strapiRow = await getStrapiRowAfterTransaction({
               contentTypeService,
               contentType,
               documentId,
-              entriesQuery: resolveFallbackEntriesQuery({
-                entriesQuery,
+              syncQuery: resolveLocaleScopedReadQuery({
+                syncQuery,
                 actionParams: ctx?.params,
               }),
             })
           }
 
-          if (entriesToUpdate.length === 0 && entry) {
-            entriesToUpdate = [entry]
+          if (entriesToUpdate.length === 0 && strapiRow) {
+            entriesToUpdate = [strapiRow]
           }
         }
 
@@ -524,11 +531,11 @@ export default async function registerDocumentMiddleware({ strapi }) {
           await meilisearch.deleteEntriesFromMeiliSearch({
             contentType,
             documentIds: [documentId],
-            entriesQuery,
+            entriesQuery: syncQuery,
           })
         } else {
           strapi.log.info(
-            `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable entry in result payload`,
+            `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi row in action result`,
           )
         }
       } else if (shouldTreatAsDeleteAction) {
@@ -539,10 +546,10 @@ export default async function registerDocumentMiddleware({ strapi }) {
           await meilisearch.deleteEntriesFromMeiliSearch({
             contentType,
             documentIds: [documentId],
-            entriesQuery,
+            entriesQuery: syncQuery,
             locales:
-              shouldDeleteByLocale && preDeleteLocales.length > 0
-                ? preDeleteLocales
+              indexSyncUsesWildcardLocale && localeCodesToRemove.length > 0
+                ? localeCodesToRemove
                 : undefined,
           })
         } else {

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -1,452 +1,236 @@
 import { isWildcardLocale } from '../meilisearch/config'
+import {
+  resolveDocumentIds,
+  resolveDocumentIdsFromActionParams,
+} from './document-ids.js'
+import {
+  extractStrapiEntryCandidates,
+  isPublishedStrapiEntry,
+} from './entry-candidates.js'
+import {
+  selectDraftEntriesForDiscardDraftResult,
+  selectPublishedEntriesForWildcardPublish,
+  selectStrapiEntryToIndexFromResult,
+} from './entry-selection.js'
+import {
+  collectLocaleCodesFromEntries,
+  getActionLocale,
+  resolveLocaleCodesToRemoveFromActionResult,
+  resolveLocaleCodesToRemoveFromIndex,
+  resolveLocaleScopedReadQuery,
+} from './locale-resolution.js'
+
+/**
+ * Fetch a Strapi entry on the next event-loop turn to avoid leaking finished transactions.
+ *
+ * @param {object} options - Fetch options.
+ * @param {object} options.contentTypeService - Plugin content type service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object} options.syncQuery - Query used to fetch the indexable Strapi entry.
+ *
+ * @returns {Promise<object|null>} Strapi entry to index or null.
+ */
+const getStrapiEntryAfterTransaction = ({
+  contentTypeService,
+  contentType,
+  documentId,
+  syncQuery,
+}) =>
+  new Promise((resolve, reject) => {
+    setImmediate(async () => {
+      try {
+        const strapiEntry = await contentTypeService.getEntry({
+          contentType,
+          documentId,
+          entriesQuery: { ...syncQuery },
+        })
+        resolve(strapiEntry)
+      } catch (error) {
+        reject(error)
+      }
+    })
+  })
+
+/**
+ * Build the pre-action snapshot for one document id.
+ *
+ * @param {object} options - Snapshot options.
+ * @param {object} options.contentTypeService - Plugin content type service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object|null|undefined} options.statusFilter - Optional status scope from sync query.
+ * @param {object|null|undefined} options.actionParams - Action params from middleware context.
+ * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ *
+ * @returns {Promise<{documentId: string, preDeleteStrapiEntry: object|null, localeVariants: object[], localeCodesToRemove: string[]}>}
+ */
+const buildPreActionSnapshot = async ({
+  contentTypeService,
+  contentType,
+  documentId,
+  statusFilter,
+  actionParams,
+  indexSyncUsesWildcardLocale,
+}) => {
+  const preDeleteStrapiEntry = await contentTypeService.getEntry({
+    contentType,
+    documentId,
+    entriesQuery: { ...(statusFilter || {}) },
+  })
+
+  const shouldFetchLocaleVariants =
+    indexSyncUsesWildcardLocale && isWildcardLocale(actionParams?.locale)
+  const localeVariants = shouldFetchLocaleVariants
+    ? await contentTypeService.getEntries({
+        contentType,
+        fields: ['documentId', 'locale'],
+        locale: '*',
+        ...(statusFilter || {}),
+        filters: {
+          documentId,
+        },
+      })
+    : []
+
+  const localeCodesToRemove = indexSyncUsesWildcardLocale
+    ? resolveLocaleCodesToRemoveFromIndex({
+        actionParams,
+        preDeleteStrapiEntry,
+        localeVariants,
+      })
+    : []
+
+  return {
+    documentId,
+    preDeleteStrapiEntry,
+    localeVariants,
+    localeCodesToRemove,
+  }
+}
+
+/**
+ * Collect pre-action snapshots for every target document.
+ *
+ * @param {object} options - Snapshot collection options.
+ * @param {string[]} options.documentIds - Target document ids.
+ * @param {object} options.contentTypeService - Plugin content type service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {object|null|undefined} options.statusFilter - Optional status scope from sync query.
+ * @param {object|null|undefined} options.actionParams - Action params from middleware context.
+ * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ *
+ * @returns {Promise<Array<{documentId: string, preDeleteStrapiEntry: object|null, localeVariants: object[], localeCodesToRemove: string[]}>>}
+ */
+const collectPreActionSnapshots = async ({
+  documentIds,
+  contentTypeService,
+  contentType,
+  statusFilter,
+  actionParams,
+  indexSyncUsesWildcardLocale,
+}) => {
+  return Promise.all(
+    documentIds.map(documentId =>
+      buildPreActionSnapshot({
+        contentTypeService,
+        contentType,
+        documentId,
+        statusFilter,
+        actionParams,
+        indexSyncUsesWildcardLocale,
+      }),
+    ),
+  )
+}
+
+/**
+ * Normalize locale codes into a stable, unique list.
+ *
+ * @param {string[]|null|undefined} localeCodes - Locale codes to normalize.
+ *
+ * @returns {string[]} Normalized locale codes.
+ */
+const normalizeLocaleCodes = localeCodes => {
+  return [
+    ...new Set(
+      (localeCodes || [])
+        .filter(locale => typeof locale === 'string' && locale.length > 0)
+        .map(locale => locale.trim()),
+    ),
+  ]
+}
+
+/**
+ * Dispatch one or more Meilisearch delete requests.
+ *
+ * The middleware batches deletes when targets share the same locale set and
+ * fans out to per-document deletes when locale scopes differ.
+ *
+ * @param {object} options - Delete dispatch options.
+ * @param {object} options.meilisearch - Meilisearch plugin service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {object} options.syncQuery - Plugin sync query configuration.
+ * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ * @param {{documentId: string, localeCodes?: string[]}[]} options.targets - Delete targets.
+ *
+ * @returns {Promise<void>}
+ */
+const dispatchDeleteTargets = async ({
+  meilisearch,
+  contentType,
+  syncQuery,
+  indexSyncUsesWildcardLocale,
+  targets,
+}) => {
+  const validTargets = (targets || []).filter(
+    target =>
+      target &&
+      typeof target.documentId === 'string' &&
+      target.documentId.length > 0,
+  )
+  if (validTargets.length === 0) return
+
+  const groupedTargets = new Map()
+  validTargets.forEach(target => {
+    const localeCodes = indexSyncUsesWildcardLocale
+      ? normalizeLocaleCodes(target.localeCodes)
+      : []
+    const groupKey =
+      localeCodes.length > 0
+        ? [...localeCodes].sort().join('|')
+        : '__no-locales__'
+    const currentGroup = groupedTargets.get(groupKey)
+    if (currentGroup) {
+      currentGroup.documentIds.push(target.documentId)
+      return
+    }
+
+    groupedTargets.set(groupKey, {
+      documentIds: [target.documentId],
+      localeCodes,
+    })
+  })
+
+  for (const group of groupedTargets.values()) {
+    await meilisearch.deleteEntriesFromMeiliSearch({
+      contentType,
+      documentIds: [...new Set(group.documentIds)],
+      entriesQuery: syncQuery,
+      locales:
+        indexSyncUsesWildcardLocale && group.localeCodes.length > 0
+          ? group.localeCodes
+          : undefined,
+    })
+  }
+}
 
 export default async function registerDocumentMiddleware({ strapi }) {
   if (!strapi?.documents || typeof strapi.documents.use !== 'function') {
     return
   }
 
-  /**
-   * Convert document service results into Strapi entry candidates with source metadata.
-   *
-   * @param {object|object[]|null|undefined} result - Value returned by document service.
-   *
-   * @returns {{data: object, source: string}[]} Flat list of potential Strapi entry candidates.
-   */
-  const extractStrapiEntryCandidates = result => {
-    if (result == null) return []
-
-    const candidates = []
-    const appendCandidate = (data, source) => {
-      if (data != null && typeof data === 'object') {
-        candidates.push({ data, source })
-      }
-    }
-
-    if (Array.isArray(result)) {
-      result.forEach(data => appendCandidate(data, 'root'))
-      return candidates
-    }
-
-    appendCandidate(result, 'root')
-
-    if (Array.isArray(result.versions)) {
-      result.versions.forEach(data => appendCandidate(data, 'versions'))
-    }
-
-    if (Array.isArray(result.entries)) {
-      result.entries.forEach(data => appendCandidate(data, 'entries'))
-    }
-
-    if (result.entry != null) {
-      appendCandidate(result.entry, 'entry')
-    }
-
-    return candidates
-  }
-
-  /**
-   * Determine whether a Strapi entry represents a published version.
-   *
-   * @param {object} entry - Strapi entry candidate.
-   *
-   * @returns {boolean} True when `publishedAt` is set.
-   */
-  const isPublishedStrapiEntry = entry =>
-    !(entry?.publishedAt === undefined || entry?.publishedAt === null)
-
-  /**
-   * Rank Strapi entry candidates by entry-likeness so nested entries beat root wrappers.
-   * Rule 1: Real DB entries (has 'id' primary key) beat wrappers (no 'id').
-   * Rule 2: Nested sources ('versions', 'entries') beat the 'root' source.
-   *
-   * @param {{data: object, source: string}[]} candidates - Candidates matching one Strapi document id.
-   *
-   * @returns {{data: object, source: string}[]} Ranked Strapi entry candidates.
-   */
-  const rankStrapiEntryCandidates = candidates => {
-    return [...candidates].sort((a, b) => {
-      const aHasPrimaryKey = a.data?.id != null
-      const bHasPrimaryKey = b.data?.id != null
-
-      if (aHasPrimaryKey && !bHasPrimaryKey) return -1
-      if (!aHasPrimaryKey && bHasPrimaryKey) return 1
-
-      const aIsRoot = a.source === 'root'
-      const bIsRoot = b.source === 'root'
-
-      if (!aIsRoot && bIsRoot) return -1
-      if (aIsRoot && !bIsRoot) return 1
-
-      return 0
-    })
-  }
-
-  /**
-   * Pick the Strapi entry to index for update-like Strapi document actions.
-   *
-   * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
-   * @param {string} options.documentId - Target Strapi document id.
-   * @param {object} options.syncQuery - Plugin sync query configuration.
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   *
-   * @returns {object|null} Selected Strapi entry to index, if any.
-   */
-  const selectStrapiEntryToIndexFromResult = ({
-    resultCandidates,
-    documentId,
-    syncQuery,
-    actionParams,
-  }) => {
-    const strapiDocumentEntryCandidates = (resultCandidates || []).filter(
-      candidate => candidate?.data?.documentId === documentId,
-    )
-    if (strapiDocumentEntryCandidates.length === 0) return null
-
-    const rankedEntryCandidates = rankStrapiEntryCandidates(
-      strapiDocumentEntryCandidates,
-    )
-    const preferredConcreteLocale = resolvePreferredConcreteLocale({
-      syncQuery,
-      actionParams,
-    })
-    const localeScopedEntryCandidate = preferredConcreteLocale
-      ? rankedEntryCandidates.find(
-          candidate => candidate?.data?.locale === preferredConcreteLocale,
-        )
-      : null
-
-    if (syncQuery?.status === 'draft') {
-      const isIndexableDraftEntryCandidate = candidate =>
-        candidate?.data?.id != null && !isPublishedStrapiEntry(candidate.data)
-      if (preferredConcreteLocale) {
-        return localeScopedEntryCandidate &&
-          isIndexableDraftEntryCandidate(localeScopedEntryCandidate)
-          ? localeScopedEntryCandidate.data
-          : null
-      }
-
-      const draftEntryCandidate = rankedEntryCandidates.find(
-        isIndexableDraftEntryCandidate,
-      )
-      return draftEntryCandidate?.data || null
-    }
-
-    if (preferredConcreteLocale) {
-      return localeScopedEntryCandidate &&
-        isPublishedStrapiEntry(localeScopedEntryCandidate.data)
-        ? localeScopedEntryCandidate.data
-        : null
-    }
-
-    const publishedEntryCandidate = rankedEntryCandidates.find(candidate =>
-      isPublishedStrapiEntry(candidate.data),
-    )
-
-    return publishedEntryCandidate?.data || null
-  }
-
-  /**
-   * Fetch a Strapi entry on the next event-loop turn to avoid leaking finished transactions.
-   *
-   * @param {object} options
-   * @param {object} options.contentTypeService - Plugin content type service.
-   * @param {string} options.contentType - Content type uid.
-   * @param {string} options.documentId - Target Strapi document id.
-   * @param {object} options.syncQuery - Query used to fetch the indexable Strapi entry.
-   *
-   * @returns {Promise<object|null>} Strapi entry to index or null.
-   */
-  const getStrapiEntryAfterTransaction = ({
-    contentTypeService,
-    contentType,
-    documentId,
-    syncQuery,
-  }) =>
-    new Promise((resolve, reject) => {
-      setImmediate(async () => {
-        try {
-          const strapiEntry = await contentTypeService.getEntry({
-            contentType,
-            documentId,
-            entriesQuery: { ...syncQuery },
-          })
-          resolve(strapiEntry)
-        } catch (error) {
-          reject(error)
-        }
-      })
-    })
-
-  /**
-   * Resolve an explicit action locale from middleware params.
-   *
-   * @param {object|null|undefined} actionParams - Action params from document middleware context.
-   *
-   * @returns {string|null} Locale from params when present.
-   */
-  const getActionLocale = actionParams => {
-    return typeof actionParams?.locale === 'string' &&
-      actionParams.locale.length > 0
-      ? actionParams.locale
-      : null
-  }
-
-  /**
-   * Resolve the concrete locale that this operation should prioritize.
-   *
-   * Priority:
-   * 1. Concrete action locale in middleware params.
-   * 2. Concrete locale from Meilisearch sync query config.
-   *
-   * @param {object} options
-   * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   *
-   * @returns {string|null} Preferred concrete locale when one is available.
-   */
-  const resolvePreferredConcreteLocale = ({ syncQuery, actionParams }) => {
-    const actionLocale = getActionLocale(actionParams)
-    if (actionLocale && !isWildcardLocale(actionLocale)) {
-      return actionLocale
-    }
-
-    const syncLocale =
-      typeof syncQuery?.locale === 'string' && syncQuery.locale.length > 0
-        ? syncQuery.locale
-        : null
-
-    if (syncLocale && !isWildcardLocale(syncLocale)) {
-      return syncLocale
-    }
-
-    return null
-  }
-
-  /**
-   * Build the locale-scoped query used by `getEntry` for update-like actions.
-   *
-   * When index config targets all locales (`*`) but the action is locale-scoped,
-   * keep every existing query option and only override `locale` with the action locale.
-   *
-   * @param {object} options
-   * @param {object|null|undefined} options.syncQuery - Base query from Meilisearch config.
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   *
-   * @returns {object} Query passed to `contentTypeService.getEntry`.
-   */
-  const resolveLocaleScopedReadQuery = ({ syncQuery, actionParams }) => {
-    const actionLocale = getActionLocale(actionParams)
-    const baseQuery = { ...(syncQuery || {}) }
-
-    if (!isWildcardLocale(baseQuery.locale) || actionLocale == null) {
-      return baseQuery
-    }
-
-    return {
-      ...baseQuery,
-      locale: actionLocale,
-    }
-  }
-
-  /**
-   * Resolve locales to remove from locale-scoped indexes for delete-like actions.
-   *
-   * @param {object} options
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {object|null} options.preDeleteStrapiEntry - Entry fetched before running the delete-like action.
-   * @param {object[]|null|undefined} options.localeVariants - Locale variants fetched for wildcard action locales.
-   *
-   * @returns {string[]} Locales to remove from Meilisearch.
-   */
-  const resolveLocaleCodesToRemoveFromIndex = ({
-    actionParams,
-    preDeleteStrapiEntry,
-    localeVariants,
-  }) => {
-    const actionLocale = getActionLocale(actionParams)
-
-    if (actionLocale && !isWildcardLocale(actionLocale)) {
-      return [actionLocale]
-    }
-
-    if (actionLocale == null) {
-      return typeof preDeleteStrapiEntry?.locale === 'string' &&
-        preDeleteStrapiEntry.locale.length > 0
-        ? [preDeleteStrapiEntry.locale]
-        : []
-    }
-
-    return [
-      ...new Set(
-        (localeVariants || [])
-          .map(entry => entry?.locale)
-          .filter(locale => typeof locale === 'string' && locale.length > 0),
-      ),
-    ]
-  }
-
-  /**
-   * Resolve locales to remove for create/publish fallback deletes on wildcard indexes.
-   *
-   * @param {object} options
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries from action result.
-   * @param {object|null|undefined} options.result - Raw action result.
-   * @param {string} options.documentId - Target Strapi document id.
-   *
-   * @returns {string[]} Locales to remove from Meilisearch.
-   */
-  const resolveLocaleCodesToRemoveFromActionResult = ({
-    actionParams,
-    resultCandidates,
-    result,
-    documentId,
-  }) => {
-    const entriesForDocument = (resultCandidates || [])
-      .map(candidate => candidate?.data)
-      .filter(entry => entry?.documentId === documentId)
-
-    const localeVariants = entriesForDocument
-      .filter(
-        entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
-      )
-      .map(entry => ({ documentId: entry.documentId, locale: entry.locale }))
-
-    const preDeleteStrapiEntry =
-      entriesForDocument.find(
-        entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
-      ) ??
-      (typeof result?.locale === 'string' && result.locale.length > 0
-        ? result
-        : (entriesForDocument[0] ?? null))
-
-    return resolveLocaleCodesToRemoveFromIndex({
-      actionParams,
-      preDeleteStrapiEntry,
-      localeVariants,
-    })
-  }
-
-  /**
-   * Resolve draft Strapi entries to index for `discardDraft` in draft-only indexes.
-   *
-   * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
-   * @param {string} options.documentId - Target Strapi document id.
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   *
-   * @returns {object[]} Draft Strapi entries scoped to the requested action locale.
-   */
-  const selectDraftEntriesForDiscardDraftResult = ({
-    resultCandidates,
-    documentId,
-    actionParams,
-  }) => {
-    const actionLocale = getActionLocale(actionParams)
-    const rankedDraftEntryCandidates = rankStrapiEntryCandidates(
-      (resultCandidates || []).filter(
-        candidate =>
-          candidate?.data?.documentId === documentId &&
-          !isPublishedStrapiEntry(candidate.data),
-      ),
-    )
-    const rankedLocalizedDraftEntryCandidates =
-      rankedDraftEntryCandidates.filter(
-        candidate =>
-          typeof candidate?.data?.locale === 'string' &&
-          candidate.data.locale.length > 0,
-      )
-
-    if (rankedDraftEntryCandidates.length === 0) return []
-
-    if (actionLocale && !isWildcardLocale(actionLocale)) {
-      const localeCandidate = rankedLocalizedDraftEntryCandidates.find(
-        candidate => candidate?.data?.locale === actionLocale,
-      )
-      return localeCandidate ? [localeCandidate.data] : []
-    }
-
-    if (actionLocale && isWildcardLocale(actionLocale)) {
-      const entriesByLocale = new Map()
-      rankedLocalizedDraftEntryCandidates.forEach(candidate => {
-        const locale = candidate.data.locale
-        if (!entriesByLocale.has(locale)) {
-          entriesByLocale.set(locale, candidate.data)
-        }
-      })
-      return [...entriesByLocale.values()]
-    }
-
-    return [
-      rankedLocalizedDraftEntryCandidates[0]?.data ||
-        rankedDraftEntryCandidates[0].data,
-    ]
-  }
-
-  /**
-   * Resolve published Strapi entries when wildcard action locale returns multiple versions.
-   *
-   * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
-   * @param {string} options.documentId - Target Strapi document id.
-   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
-   *
-   * @returns {object[]} Published Strapi entries keyed by locale/id for wildcard publish actions.
-   */
-  const selectPublishedEntriesForWildcardPublish = ({
-    resultCandidates,
-    documentId,
-    actionParams,
-    syncQuery,
-  }) => {
-    const actionLocale = getActionLocale(actionParams)
-    const syncLocale = syncQuery?.locale
-    const syncStatusScope = syncQuery?.status
-    const syncAllowsPublishedEntries =
-      syncStatusScope == null || syncStatusScope !== 'draft'
-    if (
-      !actionLocale ||
-      !isWildcardLocale(actionLocale) ||
-      !isWildcardLocale(syncLocale) ||
-      !syncAllowsPublishedEntries
-    ) {
-      return []
-    }
-
-    const rankedPublishedEntryCandidates = rankStrapiEntryCandidates(
-      (resultCandidates || []).filter(
-        candidate =>
-          candidate?.data?.documentId === documentId &&
-          isPublishedStrapiEntry(candidate.data),
-      ),
-    )
-    if (rankedPublishedEntryCandidates.length === 0) return []
-
-    const selectedEntries = []
-    const seenKeys = new Set()
-
-    rankedPublishedEntryCandidates.forEach(candidate => {
-      const strapiEntry = candidate?.data
-      if (!strapiEntry || typeof strapiEntry !== 'object') return
-
-      const localeKey =
-        typeof strapiEntry.locale === 'string' && strapiEntry.locale.length > 0
-          ? `locale:${strapiEntry.locale}`
-          : null
-      const idKey = strapiEntry.id != null ? `id:${strapiEntry.id}` : null
-      const dedupeKey = localeKey || idKey
-
-      if (!dedupeKey || seenKeys.has(dedupeKey)) return
-      seenKeys.add(dedupeKey)
-      selectedEntries.push(strapiEntry)
-    })
-
-    return selectedEntries
-  }
-
-  // Hook document service (only when available) to mirror Strapi creates into Meilisearch.
+  // Hook document service (only when available) to mirror Strapi changes into Meilisearch.
   strapi.documents.use(async (ctx, next) => {
     let result
     try {
@@ -490,88 +274,130 @@ export default async function registerDocumentMiddleware({ strapi }) {
         !shouldTreatAsUpdateAction &&
         !shouldSkipDeleteAction
 
-      const preDeleteDocumentId =
-        shouldTreatAsDeleteAction && ctx?.params?.documentId
-          ? ctx.params.documentId
-          : null
-      let preDeleteStrapiEntry = null
-      let localeCodesToRemove = []
-
-      if (preDeleteDocumentId != null) {
-        preDeleteStrapiEntry = await contentTypeService.getEntry({
-          contentType,
-          documentId: preDeleteDocumentId,
-          entriesQuery: { ...statusFilter },
-        })
-
-        if (indexSyncUsesWildcardLocale) {
-          const shouldFetchLocaleVariants = isWildcardLocale(
-            ctx?.params?.locale,
-          )
-          const localeVariants = shouldFetchLocaleVariants
-            ? await contentTypeService.getEntries({
-                contentType,
-                fields: ['documentId', 'locale'],
-                locale: '*',
-                ...statusFilter,
-                filters: {
-                  documentId: preDeleteDocumentId,
-                },
-              })
-            : []
-
-          localeCodesToRemove = resolveLocaleCodesToRemoveFromIndex({
+      const preActionDocumentIds = resolveDocumentIdsFromActionParams(
+        ctx?.params,
+      )
+      const shouldCollectPreActionSnapshots =
+        shouldTreatAsDeleteAction ||
+        (ctx.action === 'discardDraft' && isDraftIndex)
+      const preActionSnapshots = shouldCollectPreActionSnapshots
+        ? await collectPreActionSnapshots({
+            documentIds: preActionDocumentIds,
+            contentTypeService,
+            contentType,
+            statusFilter,
             actionParams: ctx?.params,
-            preDeleteStrapiEntry,
-            localeVariants,
+            indexSyncUsesWildcardLocale,
           })
-        }
-      }
+        : []
+      const preActionSnapshotsByDocumentId = new Map(
+        preActionSnapshots.map(snapshot => [snapshot.documentId, snapshot]),
+      )
 
       result = await next()
 
-      const contextDocumentId =
-        typeof ctx?.params?.documentId === 'string' &&
-        ctx.params.documentId.length > 0
-          ? ctx.params.documentId
-          : null
+      const documentIds = resolveDocumentIds({
+        actionParams: ctx?.params,
+        result,
+        preActionSnapshots,
+      })
 
-      const documentId =
-        contextDocumentId ??
-        result?.documentId ??
-        preDeleteStrapiEntry?.documentId ??
-        preDeleteDocumentId ??
-        null
-
-      if (shouldTreatAsUpdateAction && documentId != null) {
+      if (shouldTreatAsUpdateAction && documentIds.length > 0) {
         const resultCandidates = extractStrapiEntryCandidates(result)
-        let entriesToUpdate = []
+        const entriesToUpdate = []
+        const deleteTargets = []
 
-        if (ctx.action === 'discardDraft' && isDraftIndex) {
-          entriesToUpdate = selectDraftEntriesForDiscardDraftResult({
-            resultCandidates,
-            documentId,
-            actionParams: ctx?.params,
-          })
+        for (const documentId of documentIds) {
+          if (ctx.action === 'discardDraft' && isDraftIndex) {
+            const preActionSnapshot =
+              preActionSnapshotsByDocumentId.get(documentId) || null
+            const actionLocale = getActionLocale(ctx?.params)
+            const shouldLoadDraftEntriesAcrossLocales =
+              indexSyncUsesWildcardLocale && isWildcardLocale(actionLocale)
 
-          if (entriesToUpdate.length === 0) {
-            const fallbackStrapiEntry = await getStrapiEntryAfterTransaction({
-              contentTypeService,
-              contentType,
-              documentId,
-              syncQuery: resolveLocaleScopedReadQuery({
-                syncQuery,
+            const draftEntriesFromResult =
+              selectDraftEntriesForDiscardDraftResult({
+                resultCandidates,
+                documentId,
                 actionParams: ctx?.params,
-              }),
-            })
+              })
+
+            let draftEntriesToUpdate = shouldLoadDraftEntriesAcrossLocales
+              ? await contentTypeService.getEntries({
+                  contentType,
+                  locale: '*',
+                  ...statusFilter,
+                  filters: {
+                    documentId,
+                  },
+                })
+              : draftEntriesFromResult
+
+            draftEntriesToUpdate = (draftEntriesToUpdate || []).filter(
+              entry => entry && !isPublishedStrapiEntry(entry),
+            )
+
             if (
-              fallbackStrapiEntry &&
-              !isPublishedStrapiEntry(fallbackStrapiEntry)
+              draftEntriesToUpdate.length === 0 &&
+              shouldLoadDraftEntriesAcrossLocales
             ) {
-              entriesToUpdate = [fallbackStrapiEntry]
+              draftEntriesToUpdate = draftEntriesFromResult
             }
+
+            if (
+              draftEntriesToUpdate.length === 0 &&
+              !shouldLoadDraftEntriesAcrossLocales
+            ) {
+              const fallbackStrapiEntry = await getStrapiEntryAfterTransaction({
+                contentTypeService,
+                contentType,
+                documentId,
+                syncQuery: resolveLocaleScopedReadQuery({
+                  syncQuery,
+                  actionParams: ctx?.params,
+                }),
+              })
+
+              if (
+                fallbackStrapiEntry &&
+                !isPublishedStrapiEntry(fallbackStrapiEntry)
+              ) {
+                draftEntriesToUpdate = [fallbackStrapiEntry]
+              }
+            }
+
+            if (draftEntriesToUpdate.length > 0) {
+              const normalizedDraftEntries = draftEntriesToUpdate.map(entry =>
+                entry.documentId === documentId
+                  ? entry
+                  : { ...entry, documentId },
+              )
+              entriesToUpdate.push(...normalizedDraftEntries)
+            }
+
+            const preActionLocaleCodes = resolveLocaleCodesToRemoveFromIndex({
+              actionParams: ctx?.params,
+              preDeleteStrapiEntry:
+                preActionSnapshot?.preDeleteStrapiEntry || null,
+              localeVariants: preActionSnapshot?.localeVariants || [],
+            })
+            const remainingLocaleCodes =
+              collectLocaleCodesFromEntries(draftEntriesToUpdate)
+            const localeCodesToDelete = preActionLocaleCodes.filter(
+              localeCode => !remainingLocaleCodes.includes(localeCode),
+            )
+
+            if (localeCodesToDelete.length > 0) {
+              deleteTargets.push({
+                documentId,
+                localeCodes: localeCodesToDelete,
+              })
+            }
+
+            continue
           }
-        } else {
+
+          let entriesForDocument = []
           const publishedEntriesFromWildcardPublish =
             selectPublishedEntriesForWildcardPublish({
               resultCandidates,
@@ -580,7 +406,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
               syncQuery,
             })
           if (publishedEntriesFromWildcardPublish.length > 0) {
-            entriesToUpdate = publishedEntriesFromWildcardPublish
+            entriesForDocument = publishedEntriesFromWildcardPublish
           }
 
           let strapiEntry = selectStrapiEntryToIndexFromResult({
@@ -590,7 +416,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
             actionParams: ctx?.params,
           })
 
-          if (entriesToUpdate.length === 0 && !strapiEntry) {
+          if (entriesForDocument.length === 0 && !strapiEntry) {
             strapiEntry = await getStrapiEntryAfterTransaction({
               contentTypeService,
               contentType,
@@ -602,58 +428,76 @@ export default async function registerDocumentMiddleware({ strapi }) {
             })
           }
 
-          if (entriesToUpdate.length === 0 && strapiEntry) {
-            entriesToUpdate = [strapiEntry]
+          if (entriesForDocument.length === 0 && strapiEntry) {
+            entriesForDocument = [strapiEntry]
+          }
+
+          if (entriesForDocument.length > 0) {
+            const normalizedEntries = entriesForDocument.map(entry =>
+              entry.documentId === documentId
+                ? entry
+                : { ...entry, documentId },
+            )
+            entriesToUpdate.push(...normalizedEntries)
+          } else if (ctx.action === 'create' || ctx.action === 'publish') {
+            const createPublishLocaleCodesToRemove = indexSyncUsesWildcardLocale
+              ? resolveLocaleCodesToRemoveFromActionResult({
+                  actionParams: ctx?.params,
+                  resultCandidates,
+                  result,
+                  documentId,
+                })
+              : []
+
+            deleteTargets.push({
+              documentId,
+              localeCodes: createPublishLocaleCodesToRemove,
+            })
+          } else {
+            strapi.log.info(
+              `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry in action result`,
+            )
           }
         }
 
         if (entriesToUpdate.length > 0) {
-          const normalizedEntries = entriesToUpdate.map(entry =>
-            entry.documentId === documentId ? entry : { ...entry, documentId },
-          )
-
           await meilisearch.updateEntriesInMeilisearch({
             contentType,
-            entries: normalizedEntries,
+            entries: entriesToUpdate,
           })
-        } else if (ctx.action === 'create' || ctx.action === 'publish') {
-          const createPublishLocaleCodesToRemove = indexSyncUsesWildcardLocale
-            ? resolveLocaleCodesToRemoveFromActionResult({
-                actionParams: ctx?.params,
-                resultCandidates,
-                result,
-                documentId,
-              })
-            : []
+        }
 
-          await meilisearch.deleteEntriesFromMeiliSearch({
+        if (deleteTargets.length > 0) {
+          await dispatchDeleteTargets({
+            meilisearch,
             contentType,
-            documentIds: [documentId],
-            entriesQuery: syncQuery,
-            locales:
-              indexSyncUsesWildcardLocale &&
-              createPublishLocaleCodesToRemove.length > 0
-                ? createPublishLocaleCodesToRemove
-                : undefined,
+            syncQuery,
+            indexSyncUsesWildcardLocale,
+            targets: deleteTargets,
           })
-        } else {
-          strapi.log.info(
-            `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry in action result`,
-          )
         }
       } else if (shouldTreatAsDeleteAction) {
-        if (documentId != null) {
+        if (documentIds.length > 0) {
+          const deleteTargets = documentIds.map(documentId => {
+            const preActionSnapshot =
+              preActionSnapshotsByDocumentId.get(documentId) || null
+            return {
+              documentId,
+              localeCodes: indexSyncUsesWildcardLocale
+                ? preActionSnapshot?.localeCodesToRemove || []
+                : [],
+            }
+          })
+
           strapi.log.info(
-            `Meilisearch document middleware deleting ${contentType} documentId=${documentId}`,
+            `Meilisearch document middleware deleting ${contentType} documentIds=${documentIds.join(',')}`,
           )
-          await meilisearch.deleteEntriesFromMeiliSearch({
+          await dispatchDeleteTargets({
+            meilisearch,
             contentType,
-            documentIds: [documentId],
-            entriesQuery: syncQuery,
-            locales:
-              indexSyncUsesWildcardLocale && localeCodesToRemove.length > 0
-                ? localeCodesToRemove
-                : undefined,
+            syncQuery,
+            indexSyncUsesWildcardLocale,
+            targets: deleteTargets,
           })
         } else {
           strapi.log.info(

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -149,6 +149,186 @@ export default async function registerDocumentMiddleware({ strapi }) {
       })
     })
 
+  /**
+   * Resolve an explicit action locale from middleware params.
+   *
+   * @param {object|null|undefined} actionParams - Action params from document middleware context.
+   *
+   * @returns {string|null} Locale from params when present.
+   */
+  const getActionLocale = actionParams => {
+    return typeof actionParams?.locale === 'string' &&
+      actionParams.locale.length > 0
+      ? actionParams.locale
+      : null
+  }
+
+  /**
+   * Build the fallback query used by `getEntry` for update-like actions.
+   *
+   * When index config targets all locales (`*`) but the action is locale-scoped,
+   * keep every existing query option and only override `locale` with the action locale.
+   *
+   * @param {object} options
+   * @param {object|null|undefined} options.entriesQuery - Base query from Meilisearch config.
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   *
+   * @returns {object} Query passed to `contentTypeService.getEntry`.
+   */
+  const resolveFallbackEntriesQuery = ({ entriesQuery, actionParams }) => {
+    const actionLocale = getActionLocale(actionParams)
+    const baseQuery = { ...(entriesQuery || {}) }
+
+    if (!isWildcardLocale(baseQuery.locale) || actionLocale == null) {
+      return baseQuery
+    }
+
+    return {
+      ...baseQuery,
+      locale: actionLocale,
+    }
+  }
+
+  /**
+   * Resolve locales to remove from locale-scoped indexes for delete-like actions.
+   *
+   * @param {object} options
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   * @param {object|null} options.preDeleteEntry - Entry fetched before running the delete-like action.
+   * @param {object[]|null|undefined} options.localeVariants - Locale variants fetched for wildcard action locales.
+   *
+   * @returns {string[]} Locales to remove from Meilisearch.
+   */
+  const resolveDeleteLocales = ({
+    actionParams,
+    preDeleteEntry,
+    localeVariants,
+  }) => {
+    const actionLocale = getActionLocale(actionParams)
+
+    if (actionLocale && !isWildcardLocale(actionLocale)) {
+      return [actionLocale]
+    }
+
+    if (actionLocale == null) {
+      return typeof preDeleteEntry?.locale === 'string' &&
+        preDeleteEntry.locale.length > 0
+        ? [preDeleteEntry.locale]
+        : []
+    }
+
+    return [
+      ...new Set(
+        (localeVariants || [])
+          .map(entry => entry?.locale)
+          .filter(locale => typeof locale === 'string' && locale.length > 0),
+      ),
+    ]
+  }
+
+  /**
+   * Resolve draft entries to index for `discardDraft` in draft-only indexes.
+   *
+   * @param {object} options
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
+   * @param {string} options.documentId - Target document id.
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   *
+   * @returns {object[]} Draft entries scoped to the requested action locale.
+   */
+  const getDiscardDraftEntriesFromResult = ({
+    resultCandidates,
+    documentId,
+    actionParams,
+  }) => {
+    const actionLocale = getActionLocale(actionParams)
+    const rankedDraftCandidates = rankEntryCandidates(
+      (resultCandidates || []).filter(
+        candidate =>
+          candidate?.data?.documentId === documentId &&
+          !isPublishedEntry(candidate.data),
+      ),
+    )
+    const rankedLocalizedDraftCandidates = rankedDraftCandidates.filter(
+      candidate =>
+        typeof candidate?.data?.locale === 'string' &&
+        candidate.data.locale.length > 0,
+    )
+
+    if (rankedDraftCandidates.length === 0) return []
+
+    if (actionLocale && !isWildcardLocale(actionLocale)) {
+      const localeCandidate = rankedLocalizedDraftCandidates.find(
+        candidate => candidate?.data?.locale === actionLocale,
+      )
+      return localeCandidate ? [localeCandidate.data] : []
+    }
+
+    if (actionLocale && isWildcardLocale(actionLocale)) {
+      const entriesByLocale = new Map()
+      rankedLocalizedDraftCandidates.forEach(candidate => {
+        const locale = candidate.data.locale
+        if (!entriesByLocale.has(locale)) {
+          entriesByLocale.set(locale, candidate.data)
+        }
+      })
+      return [...entriesByLocale.values()]
+    }
+
+    return [
+      rankedLocalizedDraftCandidates[0]?.data || rankedDraftCandidates[0].data,
+    ]
+  }
+
+  /**
+   * Resolve publish entries when wildcard action locale returns multiple versions.
+   *
+   * @param {object} options
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
+   * @param {string} options.documentId - Target document id.
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   *
+   * @returns {object[]} Published entries keyed by locale/id for wildcard publish actions.
+   */
+  const getPublishEntriesFromResult = ({
+    resultCandidates,
+    documentId,
+    actionParams,
+  }) => {
+    const actionLocale = getActionLocale(actionParams)
+    if (!actionLocale || !isWildcardLocale(actionLocale)) return []
+
+    const rankedPublishedCandidates = rankEntryCandidates(
+      (resultCandidates || []).filter(
+        candidate =>
+          candidate?.data?.documentId === documentId &&
+          isPublishedEntry(candidate.data),
+      ),
+    )
+    if (rankedPublishedCandidates.length === 0) return []
+
+    const selectedEntries = []
+    const seenKeys = new Set()
+
+    rankedPublishedCandidates.forEach(candidate => {
+      const entry = candidate?.data
+      if (!entry || typeof entry !== 'object') return
+
+      const localeKey =
+        typeof entry.locale === 'string' && entry.locale.length > 0
+          ? `locale:${entry.locale}`
+          : null
+      const idKey = entry.id != null ? `id:${entry.id}` : null
+      const dedupeKey = localeKey || idKey
+
+      if (!dedupeKey || seenKeys.has(dedupeKey)) return
+      seenKeys.add(dedupeKey)
+      selectedEntries.push(entry)
+    })
+
+    return selectedEntries
+  }
+
   // Hook document service (only when available) to mirror Strapi creates into Meilisearch.
   strapi.documents.use(async (ctx, next) => {
     let result
@@ -179,9 +359,22 @@ export default async function registerDocumentMiddleware({ strapi }) {
       const { status } = entriesQuery || {}
       const statusFilter =
         typeof status === 'string' && status.length > 0 ? { status } : {}
+      const isDraftIndex = status === 'draft'
+      const isPublishedIndex = status === 'published'
+
+      const shouldSkipDeleteAction =
+        (ctx.action === 'unpublish' && isDraftIndex) ||
+        (ctx.action === 'discardDraft' && isPublishedIndex)
+      const shouldTreatAsUpdateAction =
+        updateActions.includes(ctx.action) ||
+        (ctx.action === 'discardDraft' && isDraftIndex)
+      const shouldTreatAsDeleteAction =
+        deleteActions.includes(ctx.action) &&
+        !shouldTreatAsUpdateAction &&
+        !shouldSkipDeleteAction
 
       const preDeleteDocumentId =
-        deleteActions.includes(ctx.action) && ctx?.params?.documentId
+        shouldTreatAsDeleteAction && ctx?.params?.documentId
           ? ctx.params.documentId
           : null
       let preDeleteEntry = null
@@ -195,25 +388,26 @@ export default async function registerDocumentMiddleware({ strapi }) {
         })
 
         if (shouldDeleteByLocale) {
-          const localeVariants = await contentTypeService.getEntries({
-            contentType,
-            fields: ['documentId', 'locale'],
-            locale: '*',
-            ...statusFilter,
-            filters: {
-              documentId: preDeleteDocumentId,
-            },
-          })
+          const shouldFetchLocaleVariants = isWildcardLocale(
+            ctx?.params?.locale,
+          )
+          const localeVariants = shouldFetchLocaleVariants
+            ? await contentTypeService.getEntries({
+                contentType,
+                fields: ['documentId', 'locale'],
+                locale: '*',
+                ...statusFilter,
+                filters: {
+                  documentId: preDeleteDocumentId,
+                },
+              })
+            : []
 
-          preDeleteLocales = [
-            ...new Set(
-              localeVariants
-                .map(entry => entry?.locale)
-                .filter(
-                  locale => typeof locale === 'string' && locale.length > 0,
-                ),
-            ),
-          ]
+          preDeleteLocales = resolveDeleteLocales({
+            actionParams: ctx?.params,
+            preDeleteEntry,
+            localeVariants,
+          })
         }
       }
 
@@ -232,30 +426,69 @@ export default async function registerDocumentMiddleware({ strapi }) {
         preDeleteDocumentId ??
         null
 
-      if (updateActions.includes(ctx.action) && documentId != null) {
+      if (shouldTreatAsUpdateAction && documentId != null) {
         const resultCandidates = extractEntryCandidates(result)
-        let entry = getEntryFromResult({
-          resultCandidates,
-          documentId,
-          entriesQuery,
-        })
+        let entriesToUpdate = []
 
-        if (!entry) {
-          entry = await getEntryOutsideTransaction({
-            contentTypeService,
-            contentType,
+        if (ctx.action === 'discardDraft' && isDraftIndex) {
+          entriesToUpdate = getDiscardDraftEntriesFromResult({
+            resultCandidates,
+            documentId,
+            actionParams: ctx?.params,
+          })
+
+          if (entriesToUpdate.length === 0) {
+            const fallbackEntry = await getEntryOutsideTransaction({
+              contentTypeService,
+              contentType,
+              documentId,
+              entriesQuery,
+            })
+            if (fallbackEntry && !isPublishedEntry(fallbackEntry)) {
+              entriesToUpdate = [fallbackEntry]
+            }
+          }
+        } else {
+          const publishResultEntries = getPublishEntriesFromResult({
+            resultCandidates,
+            documentId,
+            actionParams: ctx?.params,
+          })
+          if (publishResultEntries.length > 0) {
+            entriesToUpdate = publishResultEntries
+          }
+
+          let entry = getEntryFromResult({
+            resultCandidates,
             documentId,
             entriesQuery,
           })
+
+          if (entriesToUpdate.length === 0 && !entry) {
+            entry = await getEntryOutsideTransaction({
+              contentTypeService,
+              contentType,
+              documentId,
+              entriesQuery: resolveFallbackEntriesQuery({
+                entriesQuery,
+                actionParams: ctx?.params,
+              }),
+            })
+          }
+
+          if (entriesToUpdate.length === 0 && entry) {
+            entriesToUpdate = [entry]
+          }
         }
 
-        if (entry) {
-          const normalizedEntry =
-            entry.documentId === documentId ? entry : { ...entry, documentId }
+        if (entriesToUpdate.length > 0) {
+          const normalizedEntries = entriesToUpdate.map(entry =>
+            entry.documentId === documentId ? entry : { ...entry, documentId },
+          )
 
           await meilisearch.updateEntriesInMeilisearch({
             contentType,
-            entries: [normalizedEntry],
+            entries: normalizedEntries,
           })
         } else if (ctx.action === 'create' || ctx.action === 'publish') {
           await meilisearch.deleteEntriesFromMeiliSearch({
@@ -268,7 +501,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
             `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable entry in result payload`,
           )
         }
-      } else if (deleteActions.includes(ctx.action)) {
+      } else if (shouldTreatAsDeleteAction) {
         if (documentId != null) {
           strapi.log.info(
             `Meilisearch document middleware deleting ${contentType} documentId=${documentId}`,

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -246,6 +246,48 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
+   * Resolve locales to remove for create/publish fallback deletes on wildcard indexes.
+   *
+   * @param {object} options
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries from action result.
+   * @param {object|null|undefined} options.result - Raw action result.
+   * @param {string} options.documentId - Target Strapi document id.
+   *
+   * @returns {string[]} Locales to remove from Meilisearch.
+   */
+  const resolveLocaleCodesToRemoveFromActionResult = ({
+    actionParams,
+    resultCandidates,
+    result,
+    documentId,
+  }) => {
+    const entriesForDocument = (resultCandidates || [])
+      .map(candidate => candidate?.data)
+      .filter(entry => entry?.documentId === documentId)
+
+    const localeVariants = entriesForDocument
+      .filter(
+        entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
+      )
+      .map(entry => ({ documentId: entry.documentId, locale: entry.locale }))
+
+    const preDeleteStrapiEntry =
+      entriesForDocument.find(
+        entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
+      ) ??
+      (typeof result?.locale === 'string' && result.locale.length > 0
+        ? result
+        : (entriesForDocument[0] ?? null))
+
+    return resolveLocaleCodesToRemoveFromIndex({
+      actionParams,
+      preDeleteStrapiEntry,
+      localeVariants,
+    })
+  }
+
+  /**
    * Resolve draft Strapi entries to index for `discardDraft` in draft-only indexes.
    *
    * @param {object} options
@@ -532,10 +574,24 @@ export default async function registerDocumentMiddleware({ strapi }) {
             entries: normalizedEntries,
           })
         } else if (ctx.action === 'create' || ctx.action === 'publish') {
+          const createPublishLocaleCodesToRemove = indexSyncUsesWildcardLocale
+            ? resolveLocaleCodesToRemoveFromActionResult({
+                actionParams: ctx?.params,
+                resultCandidates,
+                result,
+                documentId,
+              })
+            : []
+
           await meilisearch.deleteEntriesFromMeiliSearch({
             contentType,
             documentIds: [documentId],
             entriesQuery: syncQuery,
+            locales:
+              indexSyncUsesWildcardLocale &&
+              createPublishLocaleCodesToRemove.length > 0
+                ? createPublishLocaleCodesToRemove
+                : undefined,
           })
         } else {
           strapi.log.info(

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -88,6 +88,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
    * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
    * @param {string} options.documentId - Target document id.
    * @param {object} options.entriesQuery - Plugin entries query configuration.
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
    * @returns {object|null} Selected entry to index, if any.
    */
@@ -95,6 +96,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
     resultCandidates,
     documentId,
     entriesQuery,
+    actionParams,
   }) => {
     const documentCandidates = (resultCandidates || []).filter(
       candidate => candidate?.data?.documentId === documentId,
@@ -102,17 +104,29 @@ export default async function registerDocumentMiddleware({ strapi }) {
     if (documentCandidates.length === 0) return null
 
     const rankedCandidates = rankEntryCandidates(documentCandidates)
+    const actionLocale = getActionLocale(actionParams)
+    const localeScopedCandidate =
+      actionLocale && !isWildcardLocale(actionLocale)
+        ? rankedCandidates.find(
+            candidate => candidate?.data?.locale === actionLocale,
+          )
+        : null
 
     if (entriesQuery?.status === 'draft') {
-      const draftCandidate = rankedCandidates.find(
-        candidate => !isPublishedEntry(candidate.data),
-      )
-      return draftCandidate?.data || rankedCandidates[0]?.data || null
+      const isIndexableDraftCandidate = candidate =>
+        candidate?.data?.id != null && !isPublishedEntry(candidate.data)
+      const draftCandidate =
+        localeScopedCandidate &&
+        isIndexableDraftCandidate(localeScopedCandidate)
+          ? localeScopedCandidate
+          : rankedCandidates.find(isIndexableDraftCandidate)
+      return draftCandidate?.data || null
     }
 
-    const publishedCandidate = rankedCandidates.find(candidate =>
-      isPublishedEntry(candidate.data),
-    )
+    const publishedCandidate =
+      localeScopedCandidate && isPublishedEntry(localeScopedCandidate.data)
+        ? localeScopedCandidate
+        : rankedCandidates.find(candidate => isPublishedEntry(candidate.data))
 
     return publishedCandidate?.data || null
   }
@@ -287,6 +301,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
    * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate entries extracted from result.
    * @param {string} options.documentId - Target document id.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   * @param {object|null|undefined} options.entriesQuery - Plugin entries query configuration.
    *
    * @returns {object[]} Published entries keyed by locale/id for wildcard publish actions.
    */
@@ -294,9 +309,19 @@ export default async function registerDocumentMiddleware({ strapi }) {
     resultCandidates,
     documentId,
     actionParams,
+    entriesQuery,
   }) => {
     const actionLocale = getActionLocale(actionParams)
-    if (!actionLocale || !isWildcardLocale(actionLocale)) return []
+    const statusScope = entriesQuery?.status
+    const allowsPublishedEntries =
+      statusScope == null || statusScope !== 'draft'
+    if (
+      !actionLocale ||
+      !isWildcardLocale(actionLocale) ||
+      !allowsPublishedEntries
+    ) {
+      return []
+    }
 
     const rankedPublishedCandidates = rankEntryCandidates(
       (resultCandidates || []).filter(
@@ -442,7 +467,10 @@ export default async function registerDocumentMiddleware({ strapi }) {
               contentTypeService,
               contentType,
               documentId,
-              entriesQuery,
+              entriesQuery: resolveFallbackEntriesQuery({
+                entriesQuery,
+                actionParams: ctx?.params,
+              }),
             })
             if (fallbackEntry && !isPublishedEntry(fallbackEntry)) {
               entriesToUpdate = [fallbackEntry]
@@ -453,6 +481,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
             resultCandidates,
             documentId,
             actionParams: ctx?.params,
+            entriesQuery,
           })
           if (publishResultEntries.length > 0) {
             entriesToUpdate = publishResultEntries
@@ -462,6 +491,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
             resultCandidates,
             documentId,
             entriesQuery,
+            actionParams: ctx?.params,
           })
 
           if (entriesToUpdate.length === 0 && !entry) {

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -106,32 +106,42 @@ export default async function registerDocumentMiddleware({ strapi }) {
     const rankedEntryCandidates = rankStrapiEntryCandidates(
       strapiDocumentEntryCandidates,
     )
-    const actionLocale = getActionLocale(actionParams)
-    const localeScopedEntryCandidate =
-      actionLocale && !isWildcardLocale(actionLocale)
-        ? rankedEntryCandidates.find(
-            candidate => candidate?.data?.locale === actionLocale,
-          )
-        : null
+    const preferredConcreteLocale = resolvePreferredConcreteLocale({
+      syncQuery,
+      actionParams,
+    })
+    const localeScopedEntryCandidate = preferredConcreteLocale
+      ? rankedEntryCandidates.find(
+          candidate => candidate?.data?.locale === preferredConcreteLocale,
+        )
+      : null
 
     if (syncQuery?.status === 'draft') {
       const isIndexableDraftEntryCandidate = candidate =>
         candidate?.data?.id != null && !isPublishedStrapiEntry(candidate.data)
-      const draftEntryCandidate =
-        localeScopedEntryCandidate &&
-        isIndexableDraftEntryCandidate(localeScopedEntryCandidate)
-          ? localeScopedEntryCandidate
-          : rankedEntryCandidates.find(isIndexableDraftEntryCandidate)
+      if (preferredConcreteLocale) {
+        return localeScopedEntryCandidate &&
+          isIndexableDraftEntryCandidate(localeScopedEntryCandidate)
+          ? localeScopedEntryCandidate.data
+          : null
+      }
+
+      const draftEntryCandidate = rankedEntryCandidates.find(
+        isIndexableDraftEntryCandidate,
+      )
       return draftEntryCandidate?.data || null
     }
 
-    const publishedEntryCandidate =
-      localeScopedEntryCandidate &&
-      isPublishedStrapiEntry(localeScopedEntryCandidate.data)
-        ? localeScopedEntryCandidate
-        : rankedEntryCandidates.find(candidate =>
-            isPublishedStrapiEntry(candidate.data),
-          )
+    if (preferredConcreteLocale) {
+      return localeScopedEntryCandidate &&
+        isPublishedStrapiEntry(localeScopedEntryCandidate.data)
+        ? localeScopedEntryCandidate.data
+        : null
+    }
+
+    const publishedEntryCandidate = rankedEntryCandidates.find(candidate =>
+      isPublishedStrapiEntry(candidate.data),
+    )
 
     return publishedEntryCandidate?.data || null
   }
@@ -180,6 +190,37 @@ export default async function registerDocumentMiddleware({ strapi }) {
       actionParams.locale.length > 0
       ? actionParams.locale
       : null
+  }
+
+  /**
+   * Resolve the concrete locale that this operation should prioritize.
+   *
+   * Priority:
+   * 1. Concrete action locale in middleware params.
+   * 2. Concrete locale from Meilisearch sync query config.
+   *
+   * @param {object} options
+   * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
+   * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+   *
+   * @returns {string|null} Preferred concrete locale when one is available.
+   */
+  const resolvePreferredConcreteLocale = ({ syncQuery, actionParams }) => {
+    const actionLocale = getActionLocale(actionParams)
+    if (actionLocale && !isWildcardLocale(actionLocale)) {
+      return actionLocale
+    }
+
+    const syncLocale =
+      typeof syncQuery?.locale === 'string' && syncQuery.locale.length > 0
+        ? syncQuery.locale
+        : null
+
+    if (syncLocale && !isWildcardLocale(syncLocale)) {
+      return syncLocale
+    }
+
+    return null
   }
 
   /**
@@ -361,12 +402,14 @@ export default async function registerDocumentMiddleware({ strapi }) {
     syncQuery,
   }) => {
     const actionLocale = getActionLocale(actionParams)
+    const syncLocale = syncQuery?.locale
     const syncStatusScope = syncQuery?.status
     const syncAllowsPublishedEntries =
       syncStatusScope == null || syncStatusScope !== 'draft'
     if (
       !actionLocale ||
       !isWildcardLocale(actionLocale) ||
+      !isWildcardLocale(syncLocale) ||
       !syncAllowsPublishedEntries
     ) {
       return []

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -6,13 +6,13 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Convert document service results into Strapi row candidates with source metadata.
+   * Convert document service results into Strapi entry candidates with source metadata.
    *
    * @param {object|object[]|null|undefined} result - Value returned by document service.
    *
-   * @returns {{data: object, source: string}[]} Flat list of potential Strapi row candidates.
+   * @returns {{data: object, source: string}[]} Flat list of potential Strapi entry candidates.
    */
-  const extractStrapiRowCandidates = result => {
+  const extractStrapiEntryCandidates = result => {
     if (result == null) return []
 
     const candidates = []
@@ -45,25 +45,25 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Determine whether a Strapi row represents a published version.
+   * Determine whether a Strapi entry represents a published version.
    *
-   * @param {object} entry - Strapi row candidate.
+   * @param {object} entry - Strapi entry candidate.
    *
    * @returns {boolean} True when `publishedAt` is set.
    */
-  const isPublishedStrapiRow = entry =>
+  const isPublishedStrapiEntry = entry =>
     !(entry?.publishedAt === undefined || entry?.publishedAt === null)
 
   /**
-   * Rank Strapi row candidates by row-likeness so nested rows beat root wrappers.
-   * Rule 1: Real DB rows (has 'id' primary key) beat wrappers (no 'id').
+   * Rank Strapi entry candidates by entry-likeness so nested entries beat root wrappers.
+   * Rule 1: Real DB entries (has 'id' primary key) beat wrappers (no 'id').
    * Rule 2: Nested sources ('versions', 'entries') beat the 'root' source.
    *
    * @param {{data: object, source: string}[]} candidates - Candidates matching one Strapi document id.
    *
-   * @returns {{data: object, source: string}[]} Ranked Strapi row candidates.
+   * @returns {{data: object, source: string}[]} Ranked Strapi entry candidates.
    */
-  const rankStrapiRowCandidates = candidates => {
+  const rankStrapiEntryCandidates = candidates => {
     return [...candidates].sort((a, b) => {
       const aHasPrimaryKey = a.data?.id != null
       const bHasPrimaryKey = b.data?.id != null
@@ -82,72 +82,72 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Pick the Strapi row to index for update-like Strapi document actions.
+   * Pick the Strapi entry to index for update-like Strapi document actions.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
    * @param {string} options.documentId - Target Strapi document id.
    * @param {object} options.syncQuery - Plugin sync query configuration.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
-   * @returns {object|null} Selected Strapi row to index, if any.
+   * @returns {object|null} Selected Strapi entry to index, if any.
    */
-  const selectStrapiRowToIndexFromResult = ({
+  const selectStrapiEntryToIndexFromResult = ({
     resultCandidates,
     documentId,
     syncQuery,
     actionParams,
   }) => {
-    const strapiDocumentRowCandidates = (resultCandidates || []).filter(
+    const strapiDocumentEntryCandidates = (resultCandidates || []).filter(
       candidate => candidate?.data?.documentId === documentId,
     )
-    if (strapiDocumentRowCandidates.length === 0) return null
+    if (strapiDocumentEntryCandidates.length === 0) return null
 
-    const rankedRowCandidates = rankStrapiRowCandidates(
-      strapiDocumentRowCandidates,
+    const rankedEntryCandidates = rankStrapiEntryCandidates(
+      strapiDocumentEntryCandidates,
     )
     const actionLocale = getActionLocale(actionParams)
-    const localeScopedRowCandidate =
+    const localeScopedEntryCandidate =
       actionLocale && !isWildcardLocale(actionLocale)
-        ? rankedRowCandidates.find(
+        ? rankedEntryCandidates.find(
             candidate => candidate?.data?.locale === actionLocale,
           )
         : null
 
     if (syncQuery?.status === 'draft') {
-      const isIndexableDraftRowCandidate = candidate =>
-        candidate?.data?.id != null && !isPublishedStrapiRow(candidate.data)
-      const draftRowCandidate =
-        localeScopedRowCandidate &&
-        isIndexableDraftRowCandidate(localeScopedRowCandidate)
-          ? localeScopedRowCandidate
-          : rankedRowCandidates.find(isIndexableDraftRowCandidate)
-      return draftRowCandidate?.data || null
+      const isIndexableDraftEntryCandidate = candidate =>
+        candidate?.data?.id != null && !isPublishedStrapiEntry(candidate.data)
+      const draftEntryCandidate =
+        localeScopedEntryCandidate &&
+        isIndexableDraftEntryCandidate(localeScopedEntryCandidate)
+          ? localeScopedEntryCandidate
+          : rankedEntryCandidates.find(isIndexableDraftEntryCandidate)
+      return draftEntryCandidate?.data || null
     }
 
-    const publishedRowCandidate =
-      localeScopedRowCandidate &&
-      isPublishedStrapiRow(localeScopedRowCandidate.data)
-        ? localeScopedRowCandidate
-        : rankedRowCandidates.find(candidate =>
-            isPublishedStrapiRow(candidate.data),
+    const publishedEntryCandidate =
+      localeScopedEntryCandidate &&
+      isPublishedStrapiEntry(localeScopedEntryCandidate.data)
+        ? localeScopedEntryCandidate
+        : rankedEntryCandidates.find(candidate =>
+            isPublishedStrapiEntry(candidate.data),
           )
 
-    return publishedRowCandidate?.data || null
+    return publishedEntryCandidate?.data || null
   }
 
   /**
-   * Fetch a Strapi row on the next event-loop turn to avoid leaking finished transactions.
+   * Fetch a Strapi entry on the next event-loop turn to avoid leaking finished transactions.
    *
    * @param {object} options
    * @param {object} options.contentTypeService - Plugin content type service.
    * @param {string} options.contentType - Content type uid.
    * @param {string} options.documentId - Target Strapi document id.
-   * @param {object} options.syncQuery - Query used to fetch the indexable Strapi row.
+   * @param {object} options.syncQuery - Query used to fetch the indexable Strapi entry.
    *
-   * @returns {Promise<object|null>} Strapi row to index or null.
+   * @returns {Promise<object|null>} Strapi entry to index or null.
    */
-  const getStrapiRowAfterTransaction = ({
+  const getStrapiEntryAfterTransaction = ({
     contentTypeService,
     contentType,
     documentId,
@@ -156,12 +156,12 @@ export default async function registerDocumentMiddleware({ strapi }) {
     new Promise((resolve, reject) => {
       setImmediate(async () => {
         try {
-          const strapiRow = await contentTypeService.getEntry({
+          const strapiEntry = await contentTypeService.getEntry({
             contentType,
             documentId,
             entriesQuery: { ...syncQuery },
           })
-          resolve(strapiRow)
+          resolve(strapiEntry)
         } catch (error) {
           reject(error)
         }
@@ -213,14 +213,14 @@ export default async function registerDocumentMiddleware({ strapi }) {
    *
    * @param {object} options
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
-   * @param {object|null} options.preDeleteStrapiRow - Row fetched before running the delete-like action.
+   * @param {object|null} options.preDeleteStrapiEntry - Entry fetched before running the delete-like action.
    * @param {object[]|null|undefined} options.localeVariants - Locale variants fetched for wildcard action locales.
    *
    * @returns {string[]} Locales to remove from Meilisearch.
    */
   const resolveLocaleCodesToRemoveFromIndex = ({
     actionParams,
-    preDeleteStrapiRow,
+    preDeleteStrapiEntry,
     localeVariants,
   }) => {
     const actionLocale = getActionLocale(actionParams)
@@ -230,9 +230,9 @@ export default async function registerDocumentMiddleware({ strapi }) {
     }
 
     if (actionLocale == null) {
-      return typeof preDeleteStrapiRow?.locale === 'string' &&
-        preDeleteStrapiRow.locale.length > 0
-        ? [preDeleteStrapiRow.locale]
+      return typeof preDeleteStrapiEntry?.locale === 'string' &&
+        preDeleteStrapiEntry.locale.length > 0
+        ? [preDeleteStrapiEntry.locale]
         : []
     }
 
@@ -246,38 +246,39 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }
 
   /**
-   * Resolve draft Strapi rows to index for `discardDraft` in draft-only indexes.
+   * Resolve draft Strapi entries to index for `discardDraft` in draft-only indexes.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
    * @param {string} options.documentId - Target Strapi document id.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    *
-   * @returns {object[]} Draft Strapi rows scoped to the requested action locale.
+   * @returns {object[]} Draft Strapi entries scoped to the requested action locale.
    */
-  const selectDraftRowsForDiscardDraftResult = ({
+  const selectDraftEntriesForDiscardDraftResult = ({
     resultCandidates,
     documentId,
     actionParams,
   }) => {
     const actionLocale = getActionLocale(actionParams)
-    const rankedDraftRowCandidates = rankStrapiRowCandidates(
+    const rankedDraftEntryCandidates = rankStrapiEntryCandidates(
       (resultCandidates || []).filter(
         candidate =>
           candidate?.data?.documentId === documentId &&
-          !isPublishedStrapiRow(candidate.data),
+          !isPublishedStrapiEntry(candidate.data),
       ),
     )
-    const rankedLocalizedDraftRowCandidates = rankedDraftRowCandidates.filter(
-      candidate =>
-        typeof candidate?.data?.locale === 'string' &&
-        candidate.data.locale.length > 0,
-    )
+    const rankedLocalizedDraftEntryCandidates =
+      rankedDraftEntryCandidates.filter(
+        candidate =>
+          typeof candidate?.data?.locale === 'string' &&
+          candidate.data.locale.length > 0,
+      )
 
-    if (rankedDraftRowCandidates.length === 0) return []
+    if (rankedDraftEntryCandidates.length === 0) return []
 
     if (actionLocale && !isWildcardLocale(actionLocale)) {
-      const localeCandidate = rankedLocalizedDraftRowCandidates.find(
+      const localeCandidate = rankedLocalizedDraftEntryCandidates.find(
         candidate => candidate?.data?.locale === actionLocale,
       )
       return localeCandidate ? [localeCandidate.data] : []
@@ -285,7 +286,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
 
     if (actionLocale && isWildcardLocale(actionLocale)) {
       const entriesByLocale = new Map()
-      rankedLocalizedDraftRowCandidates.forEach(candidate => {
+      rankedLocalizedDraftEntryCandidates.forEach(candidate => {
         const locale = candidate.data.locale
         if (!entriesByLocale.has(locale)) {
           entriesByLocale.set(locale, candidate.data)
@@ -295,23 +296,23 @@ export default async function registerDocumentMiddleware({ strapi }) {
     }
 
     return [
-      rankedLocalizedDraftRowCandidates[0]?.data ||
-        rankedDraftRowCandidates[0].data,
+      rankedLocalizedDraftEntryCandidates[0]?.data ||
+        rankedDraftEntryCandidates[0].data,
     ]
   }
 
   /**
-   * Resolve published Strapi rows when wildcard action locale returns multiple versions.
+   * Resolve published Strapi entries when wildcard action locale returns multiple versions.
    *
    * @param {object} options
-   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi rows extracted from result.
+   * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
    * @param {string} options.documentId - Target Strapi document id.
    * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
    * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
    *
-   * @returns {object[]} Published Strapi rows keyed by locale/id for wildcard publish actions.
+   * @returns {object[]} Published Strapi entries keyed by locale/id for wildcard publish actions.
    */
-  const selectPublishedRowsForWildcardPublish = ({
+  const selectPublishedEntriesForWildcardPublish = ({
     resultCandidates,
     documentId,
     actionParams,
@@ -319,45 +320,45 @@ export default async function registerDocumentMiddleware({ strapi }) {
   }) => {
     const actionLocale = getActionLocale(actionParams)
     const syncStatusScope = syncQuery?.status
-    const syncAllowsPublishedRows =
+    const syncAllowsPublishedEntries =
       syncStatusScope == null || syncStatusScope !== 'draft'
     if (
       !actionLocale ||
       !isWildcardLocale(actionLocale) ||
-      !syncAllowsPublishedRows
+      !syncAllowsPublishedEntries
     ) {
       return []
     }
 
-    const rankedPublishedRowCandidates = rankStrapiRowCandidates(
+    const rankedPublishedEntryCandidates = rankStrapiEntryCandidates(
       (resultCandidates || []).filter(
         candidate =>
           candidate?.data?.documentId === documentId &&
-          isPublishedStrapiRow(candidate.data),
+          isPublishedStrapiEntry(candidate.data),
       ),
     )
-    if (rankedPublishedRowCandidates.length === 0) return []
+    if (rankedPublishedEntryCandidates.length === 0) return []
 
-    const selectedRows = []
+    const selectedEntries = []
     const seenKeys = new Set()
 
-    rankedPublishedRowCandidates.forEach(candidate => {
-      const strapiRow = candidate?.data
-      if (!strapiRow || typeof strapiRow !== 'object') return
+    rankedPublishedEntryCandidates.forEach(candidate => {
+      const strapiEntry = candidate?.data
+      if (!strapiEntry || typeof strapiEntry !== 'object') return
 
       const localeKey =
-        typeof strapiRow.locale === 'string' && strapiRow.locale.length > 0
-          ? `locale:${strapiRow.locale}`
+        typeof strapiEntry.locale === 'string' && strapiEntry.locale.length > 0
+          ? `locale:${strapiEntry.locale}`
           : null
-      const idKey = strapiRow.id != null ? `id:${strapiRow.id}` : null
+      const idKey = strapiEntry.id != null ? `id:${strapiEntry.id}` : null
       const dedupeKey = localeKey || idKey
 
       if (!dedupeKey || seenKeys.has(dedupeKey)) return
       seenKeys.add(dedupeKey)
-      selectedRows.push(strapiRow)
+      selectedEntries.push(strapiEntry)
     })
 
-    return selectedRows
+    return selectedEntries
   }
 
   // Hook document service (only when available) to mirror Strapi creates into Meilisearch.
@@ -408,11 +409,11 @@ export default async function registerDocumentMiddleware({ strapi }) {
         shouldTreatAsDeleteAction && ctx?.params?.documentId
           ? ctx.params.documentId
           : null
-      let preDeleteStrapiRow = null
+      let preDeleteStrapiEntry = null
       let localeCodesToRemove = []
 
       if (preDeleteDocumentId != null) {
-        preDeleteStrapiRow = await contentTypeService.getEntry({
+        preDeleteStrapiEntry = await contentTypeService.getEntry({
           contentType,
           documentId: preDeleteDocumentId,
           entriesQuery: { ...statusFilter },
@@ -436,7 +437,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
 
           localeCodesToRemove = resolveLocaleCodesToRemoveFromIndex({
             actionParams: ctx?.params,
-            preDeleteStrapiRow,
+            preDeleteStrapiEntry,
             localeVariants,
           })
         }
@@ -453,23 +454,23 @@ export default async function registerDocumentMiddleware({ strapi }) {
       const documentId =
         contextDocumentId ??
         result?.documentId ??
-        preDeleteStrapiRow?.documentId ??
+        preDeleteStrapiEntry?.documentId ??
         preDeleteDocumentId ??
         null
 
       if (shouldTreatAsUpdateAction && documentId != null) {
-        const resultCandidates = extractStrapiRowCandidates(result)
+        const resultCandidates = extractStrapiEntryCandidates(result)
         let entriesToUpdate = []
 
         if (ctx.action === 'discardDraft' && isDraftIndex) {
-          entriesToUpdate = selectDraftRowsForDiscardDraftResult({
+          entriesToUpdate = selectDraftEntriesForDiscardDraftResult({
             resultCandidates,
             documentId,
             actionParams: ctx?.params,
           })
 
           if (entriesToUpdate.length === 0) {
-            const fallbackStrapiRow = await getStrapiRowAfterTransaction({
+            const fallbackStrapiEntry = await getStrapiEntryAfterTransaction({
               contentTypeService,
               contentType,
               documentId,
@@ -478,31 +479,34 @@ export default async function registerDocumentMiddleware({ strapi }) {
                 actionParams: ctx?.params,
               }),
             })
-            if (fallbackStrapiRow && !isPublishedStrapiRow(fallbackStrapiRow)) {
-              entriesToUpdate = [fallbackStrapiRow]
+            if (
+              fallbackStrapiEntry &&
+              !isPublishedStrapiEntry(fallbackStrapiEntry)
+            ) {
+              entriesToUpdate = [fallbackStrapiEntry]
             }
           }
         } else {
-          const publishedRowsFromWildcardPublish =
-            selectPublishedRowsForWildcardPublish({
+          const publishedEntriesFromWildcardPublish =
+            selectPublishedEntriesForWildcardPublish({
               resultCandidates,
               documentId,
               actionParams: ctx?.params,
               syncQuery,
             })
-          if (publishedRowsFromWildcardPublish.length > 0) {
-            entriesToUpdate = publishedRowsFromWildcardPublish
+          if (publishedEntriesFromWildcardPublish.length > 0) {
+            entriesToUpdate = publishedEntriesFromWildcardPublish
           }
 
-          let strapiRow = selectStrapiRowToIndexFromResult({
+          let strapiEntry = selectStrapiEntryToIndexFromResult({
             resultCandidates,
             documentId,
             syncQuery,
             actionParams: ctx?.params,
           })
 
-          if (entriesToUpdate.length === 0 && !strapiRow) {
-            strapiRow = await getStrapiRowAfterTransaction({
+          if (entriesToUpdate.length === 0 && !strapiEntry) {
+            strapiEntry = await getStrapiEntryAfterTransaction({
               contentTypeService,
               contentType,
               documentId,
@@ -513,8 +517,8 @@ export default async function registerDocumentMiddleware({ strapi }) {
             })
           }
 
-          if (entriesToUpdate.length === 0 && strapiRow) {
-            entriesToUpdate = [strapiRow]
+          if (entriesToUpdate.length === 0 && strapiEntry) {
+            entriesToUpdate = [strapiEntry]
           }
         }
 
@@ -535,7 +539,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
           })
         } else {
           strapi.log.info(
-            `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi row in action result`,
+            `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry in action result`,
           )
         }
       } else if (shouldTreatAsDeleteAction) {

--- a/server/src/services/document-middleware/locale-resolution.js
+++ b/server/src/services/document-middleware/locale-resolution.js
@@ -1,0 +1,168 @@
+import { isWildcardLocale } from '../meilisearch/config'
+
+/**
+ * Resolve an explicit action locale from middleware params.
+ *
+ * @param {object|null|undefined} actionParams - Action params from document middleware context.
+ *
+ * @returns {string|null} Locale from params when present.
+ */
+export const getActionLocale = actionParams => {
+  return typeof actionParams?.locale === 'string' &&
+    actionParams.locale.length > 0
+    ? actionParams.locale
+    : null
+}
+
+/**
+ * Resolve the concrete locale that this operation should prioritize.
+ *
+ * Priority:
+ * 1. Concrete action locale in middleware params.
+ * 2. Concrete locale from Meilisearch sync query config.
+ *
+ * @param {object} options - Locale resolution options.
+ * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ *
+ * @returns {string|null} Preferred concrete locale when one is available.
+ */
+export const resolvePreferredConcreteLocale = ({ syncQuery, actionParams }) => {
+  const actionLocale = getActionLocale(actionParams)
+  if (actionLocale && !isWildcardLocale(actionLocale)) {
+    return actionLocale
+  }
+
+  const syncLocale =
+    typeof syncQuery?.locale === 'string' && syncQuery.locale.length > 0
+      ? syncQuery.locale
+      : null
+
+  if (syncLocale && !isWildcardLocale(syncLocale)) {
+    return syncLocale
+  }
+
+  return null
+}
+
+/**
+ * Build the locale-scoped query used by `getEntry` for update-like actions.
+ *
+ * When index config targets all locales (`*`) but the action is locale-scoped,
+ * keep every existing query option and only override `locale` with the action locale.
+ *
+ * @param {object} options - Query resolution options.
+ * @param {object|null|undefined} options.syncQuery - Base query from Meilisearch config.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ *
+ * @returns {object} Query passed to `contentTypeService.getEntry`.
+ */
+export const resolveLocaleScopedReadQuery = ({ syncQuery, actionParams }) => {
+  const actionLocale = getActionLocale(actionParams)
+  const baseQuery = { ...(syncQuery || {}) }
+
+  if (!isWildcardLocale(baseQuery.locale) || actionLocale == null) {
+    return baseQuery
+  }
+
+  return {
+    ...baseQuery,
+    locale: actionLocale,
+  }
+}
+
+/**
+ * Resolve locales to remove from locale-scoped indexes for delete-like actions.
+ *
+ * @param {object} options - Locale removal options.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ * @param {object|null} options.preDeleteStrapiEntry - Entry fetched before running the delete-like action.
+ * @param {object[]|null|undefined} options.localeVariants - Locale variants fetched for wildcard action locales.
+ *
+ * @returns {string[]} Locales to remove from Meilisearch.
+ */
+export const resolveLocaleCodesToRemoveFromIndex = ({
+  actionParams,
+  preDeleteStrapiEntry,
+  localeVariants,
+}) => {
+  const actionLocale = getActionLocale(actionParams)
+
+  if (actionLocale && !isWildcardLocale(actionLocale)) {
+    return [actionLocale]
+  }
+
+  if (actionLocale == null) {
+    return typeof preDeleteStrapiEntry?.locale === 'string' &&
+      preDeleteStrapiEntry.locale.length > 0
+      ? [preDeleteStrapiEntry.locale]
+      : []
+  }
+
+  return [
+    ...new Set(
+      (localeVariants || [])
+        .map(entry => entry?.locale)
+        .filter(locale => typeof locale === 'string' && locale.length > 0),
+    ),
+  ]
+}
+
+/**
+ * Resolve locales to remove for create/publish fallback deletes on wildcard indexes.
+ *
+ * @param {object} options - Action-result locale removal options.
+ * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
+ * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries from action result.
+ * @param {object|null|undefined} options.result - Raw action result.
+ * @param {string} options.documentId - Target Strapi document id.
+ *
+ * @returns {string[]} Locales to remove from Meilisearch.
+ */
+export const resolveLocaleCodesToRemoveFromActionResult = ({
+  actionParams,
+  resultCandidates,
+  result,
+  documentId,
+}) => {
+  const entriesForDocument = (resultCandidates || [])
+    .map(candidate => candidate?.data)
+    .filter(entry => entry?.documentId === documentId)
+
+  const localeVariants = entriesForDocument
+    .filter(
+      entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
+    )
+    .map(entry => ({ documentId: entry.documentId, locale: entry.locale }))
+
+  const preDeleteStrapiEntry =
+    entriesForDocument.find(
+      entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
+    ) ??
+    (typeof result?.locale === 'string' && result.locale.length > 0
+      ? result
+      : (entriesForDocument[0] ?? null))
+
+  return resolveLocaleCodesToRemoveFromIndex({
+    actionParams,
+    preDeleteStrapiEntry,
+    localeVariants,
+  })
+}
+
+/**
+ * Build a unique list of locale codes from Strapi entries.
+ *
+ * @param {object[]|null|undefined} entries - Strapi entries with optional locale fields.
+ *
+ * @returns {string[]} Unique locale codes.
+ */
+export const collectLocaleCodesFromEntries = entries => {
+  return [
+    ...new Set(
+      (entries || [])
+        .map(entry => entry?.locale)
+        .filter(locale => typeof locale === 'string' && locale.length > 0),
+    ),
+  ]
+}

--- a/tests/integrations/document-relations.test.js
+++ b/tests/integrations/document-relations.test.js
@@ -51,7 +51,7 @@ async function assertPublishedRestaurantCategoriesForIndexing({
 }
 
 /**
- * Assert the draft row has the expected number of category links.
+ * Assert the draft entry has the expected number of category links.
  *
  * @param {object} options
  * @param {string} options.documentId

--- a/tests/integrations/helpers/indexed-restaurant.js
+++ b/tests/integrations/helpers/indexed-restaurant.js
@@ -1,7 +1,7 @@
 import { getDocumentOrNull } from './meilisearch'
 
 /**
- * Fetch an indexed restaurant row by Strapi `documentId`.
+ * Fetch an indexed restaurant record by Strapi `documentId`.
  *
  * Meilisearch stores this fixture with `_meilisearch_id = restaurant-<documentId>`.
  *


### PR DESCRIPTION
# Description

## Why

Fixes #1121 

## How

* **Locale-aware deletions:** Honors the specific locale being deleted or unpublished rather than broadly removing all locale variants when a wildcard (`locale: '*'`) is configured.
* **Status-aware lifecycle actions:** Prevents unwanted sync operations by ensuring `unpublish` and `discardDraft` respect the active index status (e.g., ignoring `unpublish` if the plugin is configured to only index drafts).
* **Multi-locale publishing support:** Correctly extracts and indexes all relevant locale variants when publishing multiple locales simultaneously.
* **Targeted fallback queries:** Prevents accidental index deletions during updates by explicitly passing the action's specific locale to fallback `getEntry` queries, avoiding the empty responses caused by `locale: '*'` queries.

Additionally, I extracted helpers from `document-middleware/index.js` into separate files. I also reorganize the test suite to better document the plugin behavior.

## Checklist

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide
- [x] ⚠️⚠️ **I have run Cypress E2E tests locally** ⚠️⚠️

> [!warning]
> Cypress tests are currently flaky in CI. Until they are fixed, we require that you paste your local Cypress logs to encourage local testing.

**Output from `yarn cypress run`:**

```
# Paste cypress run output here
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes Meilisearch indexing issues when i18n and Draft & Publish are enabled (resolves `#1121`) by making middleware behavior locale- and status-aware and adding broad test coverage.

Key changes
- Middleware refactor (server/src/services/document-middleware)
  - Extracted helpers for document-id resolution, entry-candidates, entry-selection, and locale-resolution to make logic explicit and testable.
  - Classifies actions into update-like vs delete-like flows; centralizes deletion dispatch.
  - Locale-scoped fallback reads: when meilisearchEntriesQuery.locale === '*', fallback getEntry reads now override only locale (use ctx.params.locale) while preserving other query options.
  - Status-aware lifecycle handling:
    - Skip unpublish when indexing drafts (entriesQuery.status === 'draft').
    - Skip discardDraft when indexing published entries (entriesQuery.status === 'published'); when applicable, discardDraft re-indexes only requested draft locales (or all locales when action locale is '*').
  - Multi-locale publish support: publishing with ctx.params.locale === '*' fans out to extract and index all published locale variants from action results, with deduplication by locale/id and correct handling when results include only non-owned locales (stale owned-locale deletions).
  - Locale-aware deletions: compute precise locale codes to remove for delete/unpublish/deleteMany when wildcard indexing is used and pass those locale sets to deleteEntriesFromMeiliSearch to avoid removing unrelated locale variants.
  - Pre-action snapshots: capture pre-delete state and compute per-document locale removals to ensure safe delete-like operations.

- New/updated helper modules
  - document-ids: resolve unique document IDs from action params/result/pre-action snapshots.
  - entry-candidates: normalize and rank result candidates; detect published entries.
  - entry-selection: choose the correct entry or entries to index for create/update/publish/discardDraft, including wildcard-locale handling.
  - locale-resolution: resolve action locales, build locale-scoped read queries, and compute locale codes to remove.

- Tests and fixtures
  - Substantially expanded tests (server/src/__tests__/document-middleware.test.js and new fixtures) covering create/update/publish/unpublish/discardDraft/deleteMany across i18n + Draft & Publish permutations.
  - Added helpers and presets for test matrices and new integration clarifications.
  - Minor renames and JSDoc/comment tweaks in other tests.

Testing
- Local Cypress E2E noted (Cypress output placeholder included).
- Extensive unit/integration tests added to cover wildcard-locale fallback, locale-scoped deletions, status-aware lifecycle actions, and multi-locale publish fan-out.

Impact
- Prevents unintended deletion of other locale variants when unpublishing/deleting with wildcard locale configs.
- Ensures discardDraft/unpublish respect entriesQuery.status, avoiding incorrect re-index/delete behavior when indexing drafts vs published.
- Correctly indexes all locale variants when publishing multiple locales.
- Avoids null fallback responses by scoping fallback reads to the action locale, preventing unintended deletions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/strapi-plugin-meilisearch/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->