### PR TITLE
Fix missing relations on document update

### DIFF
--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -341,7 +341,7 @@ describe('Meilisearch sync on Strapi document changes', () => {
     })
   })
 
-  test('update indexes the published Strapi entry even when action result id is draft', async () => {
+  test('update indexes the refetched published Strapi entry even when action result id is draft', async () => {
     const {
       strapi,
       middlewareFn,
@@ -439,7 +439,7 @@ describe('Meilisearch sync on Strapi document changes', () => {
     })
   })
 
-  test('draft-only sync indexes the draft entry from nested versions data', async () => {
+  test('draft-only sync refetches the draft entry via entriesQuery before indexing nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
@@ -447,6 +447,14 @@ describe('Meilisearch sync on Strapi document changes', () => {
       contentTypeGetEntry,
     } = createStrapiStubs({
       meilisearchEntriesQuery: { status: 'draft' },
+      contentTypeGetEntry: jest.fn(() =>
+        Promise.resolve({
+          id: 101,
+          documentId: 'abc',
+          title: 'Refetched draft entry',
+          publishedAt: null,
+        }),
+      ),
     })
 
     await registerDocumentMiddleware({ strapi })
@@ -472,20 +480,33 @@ describe('Meilisearch sync on Strapi document changes', () => {
 
     await handler(ctx, () => Promise.resolve(result))
 
+    expect(contentTypeGetEntry).toHaveBeenCalledWith({
+      contentType: ctx.uid,
+      documentId: 'abc',
+      entriesQuery: { status: 'draft' },
+    })
     expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
       contentType: ctx.uid,
-      entries: [expect.objectContaining({ id: 100, documentId: 'abc' })],
+      entries: [expect.objectContaining({ id: 101, documentId: 'abc' })],
     })
-    expect(contentTypeGetEntry).not.toHaveBeenCalled()
   })
 
-  test('published sync indexes the published entry from nested versions data', async () => {
+  test('published sync refetches the entry via entriesQuery before indexing nested versions data', async () => {
     const {
       strapi,
       middlewareFn,
       updateEntriesInMeilisearch,
       contentTypeGetEntry,
-    } = createStrapiStubs()
+    } = createStrapiStubs({
+      contentTypeGetEntry: jest.fn(() =>
+        Promise.resolve({
+          id: 201,
+          documentId: 'abc',
+          title: 'Refetched published entry',
+          publishedAt: '2024-02-01',
+        }),
+      ),
+    })
 
     await registerDocumentMiddleware({ strapi })
 
@@ -511,11 +532,15 @@ describe('Meilisearch sync on Strapi document changes', () => {
 
     await handler(ctx, () => Promise.resolve(result))
 
+    expect(contentTypeGetEntry).toHaveBeenCalledWith({
+      contentType: ctx.uid,
+      documentId: 'abc',
+      entriesQuery: {},
+    })
     expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
       contentType: ctx.uid,
-      entries: [expect.objectContaining({ id: 200, documentId: 'abc' })],
+      entries: [expect.objectContaining({ id: 201, documentId: 'abc' })],
     })
-    expect(contentTypeGetEntry).not.toHaveBeenCalled()
   })
 
   test('publish uses ctx.params.documentId when result.documentId differs', async () => {
@@ -1107,7 +1132,7 @@ describe('Meilisearch sync on Strapi document changes', () => {
       })
     })
 
-    test('discardDraft with all-locales action removes stale draft locales from the index', async () => {
+    test('discardDraft uses pre-action snapshot to remove stale draft locales from the index', async () => {
       const strapiDraftEnglishEntry = createDraftEntry({
         id: 203,
         documentId: 'doc-70',
@@ -1350,319 +1375,80 @@ describe('Meilisearch sync on Strapi document changes', () => {
     })
   })
 
-  describe('locale-specific fallback reads for all-locale indexes', () => {
-    test('create loads the requested locale from Strapi when needed', async () => {
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        contentTypeGetEntry,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: '*' },
-        contentTypeGetEntry: jest.fn(() =>
-          Promise.resolve({
-            id: 301,
-            documentId: 'doc-30',
-            locale: 'fr',
-            publishedAt: '2024-01-01',
-          }),
-        ),
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
+  describe('refetch-first indexing defaults', () => {
+    test.each([
+      {
         action: 'create',
-        params: { locale: 'fr' },
-      }
-      const result = { documentId: 'doc-30' }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(contentTypeGetEntry).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentId: 'doc-30',
-        entriesQuery: { locale: 'fr' },
-      })
-      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
-    })
-
-    test('update loads the requested locale from Strapi when needed', async () => {
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        contentTypeGetEntry,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: '*' },
-        contentTypeGetEntry: jest.fn(() =>
-          Promise.resolve({
-            id: 301,
-            documentId: 'doc-30',
-            locale: 'fr',
-            publishedAt: '2024-01-01',
-          }),
-        ),
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
+        params: {},
+      },
+      {
         action: 'update',
-        params: { documentId: 'doc-30', locale: 'fr' },
-      }
-      const result = {
-        documentId: 'doc-30',
-        versions: [
-          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
-        ],
-      }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(contentTypeGetEntry).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentId: 'doc-30',
-        entriesQuery: { locale: 'fr' },
-      })
-      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
-    })
-
-    test('update prefers the requested locale from result before reading Strapi', async () => {
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        contentTypeGetEntry,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: '*' },
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'update',
-        params: { documentId: 'doc-32', locale: 'fr' },
-      }
-      const result = {
-        documentId: 'doc-32',
-        versions: [
-          {
-            id: 601,
-            documentId: 'doc-32',
-            locale: 'en',
-            publishedAt: '2024-01-01',
-          },
-          {
-            id: 602,
-            documentId: 'doc-32',
-            locale: 'fr',
-            publishedAt: '2024-01-01',
-          },
-        ],
-      }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(contentTypeGetEntry).not.toHaveBeenCalled()
-      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        entries: [expect.objectContaining({ id: 602, locale: 'fr' })],
-      })
-    })
-
-    test('publish loads the requested locale from Strapi when needed', async () => {
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        contentTypeGetEntry,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: { locale: '*' },
-        contentTypeGetEntry: jest.fn(() =>
-          Promise.resolve({
-            id: 301,
-            documentId: 'doc-30',
-            locale: 'fr',
-            publishedAt: '2024-01-01',
-          }),
-        ),
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
+        params: { documentId: 'doc-30' },
+      },
+      {
         action: 'publish',
-        params: { documentId: 'doc-30', locale: 'fr' },
-      }
-      const result = {
-        documentId: 'doc-30',
-        versions: [
-          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
-        ],
-      }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(contentTypeGetEntry).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentId: 'doc-30',
-        entriesQuery: { locale: 'fr' },
-      })
-      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
-    })
-
-    test('locale-scoped fallback read preserves configured sync query options', async () => {
-      const configuredSyncQuery = {
-        locale: '*',
-        status: 'published',
-        fields: ['title', 'locale'],
-        populate: { image: true },
-        filters: { featured: true },
-      }
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        contentTypeGetEntry,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: configuredSyncQuery,
-        contentTypeGetEntry: jest.fn(() =>
-          Promise.resolve({
-            id: 302,
-            documentId: 'doc-31',
-            locale: 'fr',
-            publishedAt: '2024-01-01',
-          }),
-        ),
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'publish',
-        params: { documentId: 'doc-31', locale: 'fr' },
-      }
-      const result = {
-        documentId: 'doc-31',
-        versions: [
-          { id: 999, documentId: 'other-doc', publishedAt: '2024-01-01' },
-        ],
-      }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(contentTypeGetEntry).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentId: 'doc-31',
-        entriesQuery: {
-          ...configuredSyncQuery,
-          locale: 'fr',
-        },
-      })
-      expect(updateEntriesInMeilisearch).toHaveBeenCalled()
-    })
-  })
-
-  describe('publish behavior for all-locale actions', () => {
-    test('publish with all-locale action indexes every returned published locale', async () => {
-      const strapiPublishedEnglishEntry = {
-        id: 401,
-        documentId: 'doc-40',
-        locale: 'en',
-        publishedAt: '2024-01-01',
-        title: 'English published',
-      }
-      const strapiPublishedFrenchEntry = {
-        id: 402,
-        documentId: 'doc-40',
-        locale: 'fr',
-        publishedAt: '2024-01-01',
-        title: 'French published',
-      }
-
-      const { strapi, middlewareFn, updateEntriesInMeilisearch } =
-        createStrapiStubs({
-          meilisearchEntriesQuery: { locale: '*' },
+        params: { documentId: 'doc-30' },
+      },
+    ])(
+      '$action refetches via entriesQuery before indexing even when action result looks indexable',
+      async ({ action, params }) => {
+        const {
+          strapi,
+          middlewareFn,
+          updateEntriesInMeilisearch,
+          contentTypeGetEntry,
+          contentTypeGetEntries,
+        } = createStrapiStubs({
+          contentTypeGetEntry: jest.fn(() =>
+            Promise.resolve({
+              id: 301,
+              documentId: 'doc-30',
+              locale: 'fr',
+              title: 'Refetched entry',
+              publishedAt: '2024-01-02',
+            }),
+          ),
         })
 
-      await registerDocumentMiddleware({ strapi })
+        await registerDocumentMiddleware({ strapi })
 
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'publish',
-        params: { documentId: 'doc-40', locale: '*' },
-      }
-      const result = {
-        documentId: 'doc-40',
-        versions: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
-      }
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action,
+          params,
+        }
+        const result = {
+          id: 901,
+          documentId: 'doc-30',
+          locale: 'fr',
+          title: 'Action result entry',
+          publishedAt: '2024-01-01',
+        }
 
-      await handler(ctx, () => Promise.resolve(result))
+        await handler(ctx, () => Promise.resolve(result))
 
-      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        entries: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
-      })
-    })
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-30',
+          entriesQuery: {},
+        })
+        expect(contentTypeGetEntries).not.toHaveBeenCalled()
+        expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          entries: [
+            expect.objectContaining({
+              id: 301,
+              documentId: 'doc-30',
+              locale: 'fr',
+              title: 'Refetched entry',
+            }),
+          ],
+        })
+      },
+    )
 
-    test('publish with all-locale action and concrete sync locale indexes only owned locale', async () => {
-      const strapiPublishedEnglishEntry = {
-        id: 411,
-        documentId: 'doc-41',
-        locale: 'en',
-        publishedAt: '2024-01-01',
-      }
-      const strapiPublishedFrenchEntry = {
-        id: 412,
-        documentId: 'doc-41',
-        locale: 'fr',
-        publishedAt: '2024-01-01',
-      }
-
-      const {
-        strapi,
-        middlewareFn,
-        updateEntriesInMeilisearch,
-        deleteEntriesFromMeiliSearch,
-      } = createStrapiStubs({
-        meilisearchEntriesQuery: SYNC_PRESETS.frenchOnly,
-      })
-
-      await registerDocumentMiddleware({ strapi })
-
-      const handler = middlewareFn()
-      const ctx = {
-        uid: 'api::restaurant.restaurant',
-        action: 'publish',
-        params: { documentId: 'doc-41', locale: '*' },
-      }
-      const result = {
-        documentId: 'doc-41',
-        versions: [strapiPublishedEnglishEntry, strapiPublishedFrenchEntry],
-      }
-
-      await handler(ctx, () => Promise.resolve(result))
-
-      expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        entries: [strapiPublishedFrenchEntry],
-      })
-      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
-    })
-
-    test('publish with all-locale action removes stale owned locale when result omits it', async () => {
+    test('update skips indexing when refetch returns null and never indexes action-result payload', async () => {
       const {
         strapi,
         middlewareFn,
@@ -1670,7 +1456,6 @@ describe('Meilisearch sync on Strapi document changes', () => {
         deleteEntriesFromMeiliSearch,
         contentTypeGetEntry,
       } = createStrapiStubs({
-        meilisearchEntriesQuery: SYNC_PRESETS.frenchOnly,
         contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
       })
 
@@ -1679,36 +1464,198 @@ describe('Meilisearch sync on Strapi document changes', () => {
       const handler = middlewareFn()
       const ctx = {
         uid: 'api::restaurant.restaurant',
-        action: 'publish',
-        params: { documentId: 'doc-42', locale: '*' },
+        action: 'update',
+        params: { documentId: 'doc-31' },
       }
       const result = {
-        documentId: 'doc-42',
-        versions: [
-          {
-            id: 421,
-            documentId: 'doc-42',
-            locale: 'en',
-            publishedAt: '2024-01-01',
-          },
-        ],
+        id: 910,
+        documentId: 'doc-31',
+        locale: 'fr',
+        title: 'Action result entry',
+        publishedAt: '2024-01-01',
       }
 
       await handler(ctx, () => Promise.resolve(result))
 
       expect(contentTypeGetEntry).toHaveBeenCalledWith({
         contentType: ctx.uid,
-        documentId: 'doc-42',
-        entriesQuery: { locale: 'fr' },
+        documentId: 'doc-31',
+        entriesQuery: {},
       })
       expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
-      expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
-        contentType: ctx.uid,
-        documentIds: ['doc-42'],
-        entriesQuery: { locale: 'fr' },
-        locales: undefined,
-      })
+      expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
     })
+
+    test.each([
+      {
+        action: 'create',
+        params: { locale: 'fr' },
+      },
+      {
+        action: 'publish',
+        params: { documentId: 'doc-50', locale: 'fr' },
+      },
+    ])(
+      '$action performs locale-owned cleanup when refetch is null and skips action-result indexing',
+      async ({ action, params }) => {
+        const {
+          strapi,
+          middlewareFn,
+          updateEntriesInMeilisearch,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action,
+          params,
+        }
+        const result = {
+          id: 920,
+          documentId: 'doc-50',
+          locale: 'fr',
+          title: 'Action result entry',
+          publishedAt: '2024-01-01',
+          versions: [
+            {
+              id: 921,
+              documentId: 'doc-50',
+              locale: 'fr',
+              publishedAt: '2024-01-01',
+            },
+          ],
+        }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-50',
+          entriesQuery: { locale: 'fr' },
+        })
+        expect(updateEntriesInMeilisearch).not.toHaveBeenCalled()
+        expect(deleteEntriesFromMeiliSearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentIds: ['doc-50'],
+          entriesQuery: { locale: '*' },
+          locales: ['fr'],
+        })
+      },
+    )
+  })
+
+  describe('wildcard-locale refetch defaults', () => {
+    test.each([
+      {
+        action: 'create',
+        params: { locale: '*' },
+      },
+      {
+        action: 'update',
+        params: { documentId: 'doc-40', locale: '*' },
+      },
+      {
+        action: 'publish',
+        params: { documentId: 'doc-40', locale: '*' },
+      },
+    ])(
+      '$action refetches all locales via getEntries when sync and action locales are wildcard',
+      async ({ action, params }) => {
+        const refetchedEntries = [
+          {
+            id: 401,
+            documentId: 'doc-40',
+            locale: 'en',
+            publishedAt: '2024-01-01',
+            title: 'English published',
+          },
+          {
+            id: 402,
+            documentId: 'doc-40',
+            locale: 'fr',
+            publishedAt: '2024-01-01',
+            title: 'French published',
+          },
+        ]
+        const {
+          strapi,
+          middlewareFn,
+          updateEntriesInMeilisearch,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+          contentTypeGetEntries,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntries: jest.fn(() =>
+            Promise.resolve(refetchedEntries),
+          ),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action,
+          params,
+        }
+        const result = {
+          id: 930,
+          documentId: 'doc-40',
+          locale: '*',
+          versions: [
+            {
+              id: 931,
+              documentId: 'doc-40',
+              locale: 'en',
+              publishedAt: '2024-01-01',
+            },
+            {
+              id: 932,
+              documentId: 'doc-40',
+              locale: 'fr',
+              publishedAt: '2024-01-01',
+            },
+          ],
+        }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntries).toHaveBeenCalledWith(
+          expect.objectContaining({
+            contentType: ctx.uid,
+            locale: '*',
+            filters: {
+              documentId: 'doc-40',
+            },
+          }),
+        )
+        expect(contentTypeGetEntry).not.toHaveBeenCalled()
+        expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+        expect(updateEntriesInMeilisearch).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          entries: [
+            expect.objectContaining({
+              id: 401,
+              documentId: 'doc-40',
+              locale: 'en',
+            }),
+            expect.objectContaining({
+              id: 402,
+              documentId: 'doc-40',
+              locale: 'fr',
+            }),
+          ],
+        })
+      },
+    )
   })
 
   describe('bulk removal actions', () => {

--- a/server/src/__tests__/document-middleware.test.js
+++ b/server/src/__tests__/document-middleware.test.js
@@ -939,6 +939,68 @@ describe('Meilisearch sync on Strapi document changes', () => {
           locales: ['fr'],
         })
       })
+
+      test('publish fallback delete skips when no concrete locale is available', async () => {
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'publish',
+          params: { documentId: 'doc-1' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-1',
+          entriesQuery: { locale: '*' },
+        })
+        expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+      })
+
+      test('create fallback delete skips when no concrete locale is available', async () => {
+        const {
+          strapi,
+          middlewareFn,
+          deleteEntriesFromMeiliSearch,
+          contentTypeGetEntry,
+        } = createStrapiStubs({
+          meilisearchEntriesQuery: { locale: '*' },
+          contentTypeGetEntry: jest.fn(() => Promise.resolve(null)),
+        })
+
+        await registerDocumentMiddleware({ strapi })
+
+        const handler = middlewareFn()
+        const ctx = {
+          uid: 'api::restaurant.restaurant',
+          action: 'create',
+          params: { documentId: 'doc-1' },
+        }
+        const result = { documentId: 'doc-1' }
+
+        await handler(ctx, () => Promise.resolve(result))
+
+        expect(contentTypeGetEntry).toHaveBeenCalledWith({
+          contentType: ctx.uid,
+          documentId: 'doc-1',
+          entriesQuery: { locale: '*' },
+        })
+        expect(deleteEntriesFromMeiliSearch).not.toHaveBeenCalled()
+      })
     })
 
     describe('draft-only all-locale index', () => {

--- a/server/src/services/document-middleware/entry-refetch.js
+++ b/server/src/services/document-middleware/entry-refetch.js
@@ -1,0 +1,66 @@
+/**
+ * Refetch one Strapi entry on the next event-loop turn.
+ *
+ * The deferred read prevents middleware indexing reads from sharing the same
+ * transaction context as the write action.
+ *
+ * @param {object} options - Refetch options.
+ * @param {object} options.contentTypeService - Plugin content type service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object|null|undefined} options.indexingQuery - Indexing query used for refetch.
+ *
+ * @returns {Promise<object|null>} Refetched Strapi entry or null.
+ */
+export const fetchSingleEntryAfterTransaction = ({
+  contentTypeService,
+  contentType,
+  documentId,
+  indexingQuery,
+}) =>
+  new Promise((resolve, reject) => {
+    setImmediate(async () => {
+      try {
+        const strapiEntry = await contentTypeService.getEntry({
+          contentType,
+          documentId,
+          entriesQuery: { ...(indexingQuery || {}) },
+        })
+        resolve(strapiEntry)
+      } catch (error) {
+        reject(error)
+      }
+    })
+  })
+
+/**
+ * Refetch all locale variants for one Strapi document.
+ *
+ * This path is used when both action and index locale scopes are wildcard.
+ *
+ * @param {object} options - Refetch options.
+ * @param {object} options.contentTypeService - Plugin content type service.
+ * @param {string} options.contentType - Content type uid.
+ * @param {string} options.documentId - Target Strapi document id.
+ * @param {object|null|undefined} options.indexingQuery - Base indexing query.
+ *
+ * @returns {Promise<object[]>} Refetched locale variants.
+ */
+export const fetchWildcardLocaleEntriesForIndexing = ({
+  contentTypeService,
+  contentType,
+  documentId,
+  indexingQuery,
+}) => {
+  const baseIndexingQuery = indexingQuery || {}
+
+  return contentTypeService.getEntries({
+    contentType,
+    ...baseIndexingQuery,
+    locale: '*',
+    filters: {
+      ...(baseIndexingQuery.filters || {}),
+      documentId,
+    },
+  })
+}

--- a/server/src/services/document-middleware/entry-selection.js
+++ b/server/src/services/document-middleware/entry-selection.js
@@ -14,7 +14,7 @@ import { isWildcardLocale } from '../meilisearch/config'
  * @param {object} options - Entry selection options.
  * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
  * @param {string} options.documentId - Target Strapi document id.
- * @param {object} options.syncQuery - Plugin sync query configuration.
+ * @param {object} options.indexingQuery - Plugin indexing query configuration.
  * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
  *
  * @returns {object|null} Selected Strapi entry to index, if any.
@@ -22,7 +22,7 @@ import { isWildcardLocale } from '../meilisearch/config'
 export const selectStrapiEntryToIndexFromResult = ({
   resultCandidates,
   documentId,
-  syncQuery,
+  indexingQuery,
   actionParams,
 }) => {
   const strapiDocumentEntryCandidates = (resultCandidates || []).filter(
@@ -34,7 +34,7 @@ export const selectStrapiEntryToIndexFromResult = ({
     strapiDocumentEntryCandidates,
   )
   const preferredConcreteLocale = resolvePreferredConcreteLocale({
-    syncQuery,
+    indexingQuery,
     actionParams,
   })
   const localeScopedEntryCandidate = preferredConcreteLocale
@@ -43,7 +43,7 @@ export const selectStrapiEntryToIndexFromResult = ({
       )
     : null
 
-  if (syncQuery?.status === 'draft') {
+  if (indexingQuery?.status === 'draft') {
     const isIndexableDraftEntryCandidate = candidate =>
       candidate?.data?.id != null && !isPublishedStrapiEntry(candidate.data)
     if (preferredConcreteLocale) {
@@ -135,7 +135,7 @@ export const selectDraftEntriesForDiscardDraftResult = ({
  * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries extracted from result.
  * @param {string} options.documentId - Target Strapi document id.
  * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
- * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
+ * @param {object|null|undefined} options.indexingQuery - Plugin indexing query configuration.
  *
  * @returns {object[]} Published Strapi entries keyed by locale/id for wildcard publish actions.
  */
@@ -143,18 +143,18 @@ export const selectPublishedEntriesForWildcardPublish = ({
   resultCandidates,
   documentId,
   actionParams,
-  syncQuery,
+  indexingQuery,
 }) => {
   const actionLocale = getActionLocale(actionParams)
-  const syncLocale = syncQuery?.locale
-  const syncStatusScope = syncQuery?.status
-  const syncAllowsPublishedEntries =
-    syncStatusScope == null || syncStatusScope !== 'draft'
+  const indexingLocale = indexingQuery?.locale
+  const indexingStatusScope = indexingQuery?.status
+  const indexingAllowsPublishedEntries =
+    indexingStatusScope == null || indexingStatusScope !== 'draft'
   if (
     !actionLocale ||
     !isWildcardLocale(actionLocale) ||
-    !isWildcardLocale(syncLocale) ||
-    !syncAllowsPublishedEntries
+    !isWildcardLocale(indexingLocale) ||
+    !indexingAllowsPublishedEntries
   ) {
     return []
   }

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -421,10 +421,12 @@ export default async function registerDocumentMiddleware({ strapi }) {
                 ? [localeScopedRefetchQuery.locale]
                 : []
 
-            deleteTargets.push({
-              documentId,
-              localeCodes: createPublishLocaleCodesToRemove,
-            })
+            if (createPublishLocaleCodesToRemove.length > 0) {
+              deleteTargets.push({
+                documentId,
+                localeCodes: createPublishLocaleCodesToRemove,
+              })
+            }
           } else {
             strapi.log.info(
               `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry after refetch`,

--- a/server/src/services/document-middleware/index.js
+++ b/server/src/services/document-middleware/index.js
@@ -7,50 +7,17 @@ import {
   extractStrapiEntryCandidates,
   isPublishedStrapiEntry,
 } from './entry-candidates.js'
-import {
-  selectDraftEntriesForDiscardDraftResult,
-  selectPublishedEntriesForWildcardPublish,
-  selectStrapiEntryToIndexFromResult,
-} from './entry-selection.js'
+import { selectDraftEntriesForDiscardDraftResult } from './entry-selection.js'
 import {
   collectLocaleCodesFromEntries,
   getActionLocale,
-  resolveLocaleCodesToRemoveFromActionResult,
   resolveLocaleCodesToRemoveFromIndex,
-  resolveLocaleScopedReadQuery,
+  resolveLocaleScopedRefetchQuery,
 } from './locale-resolution.js'
-
-/**
- * Fetch a Strapi entry on the next event-loop turn to avoid leaking finished transactions.
- *
- * @param {object} options - Fetch options.
- * @param {object} options.contentTypeService - Plugin content type service.
- * @param {string} options.contentType - Content type uid.
- * @param {string} options.documentId - Target Strapi document id.
- * @param {object} options.syncQuery - Query used to fetch the indexable Strapi entry.
- *
- * @returns {Promise<object|null>} Strapi entry to index or null.
- */
-const getStrapiEntryAfterTransaction = ({
-  contentTypeService,
-  contentType,
-  documentId,
-  syncQuery,
-}) =>
-  new Promise((resolve, reject) => {
-    setImmediate(async () => {
-      try {
-        const strapiEntry = await contentTypeService.getEntry({
-          contentType,
-          documentId,
-          entriesQuery: { ...syncQuery },
-        })
-        resolve(strapiEntry)
-      } catch (error) {
-        reject(error)
-      }
-    })
-  })
+import {
+  fetchSingleEntryAfterTransaction,
+  fetchWildcardLocaleEntriesForIndexing,
+} from './entry-refetch.js'
 
 /**
  * Build the pre-action snapshot for one document id.
@@ -59,9 +26,9 @@ const getStrapiEntryAfterTransaction = ({
  * @param {object} options.contentTypeService - Plugin content type service.
  * @param {string} options.contentType - Content type uid.
  * @param {string} options.documentId - Target Strapi document id.
- * @param {object|null|undefined} options.statusFilter - Optional status scope from sync query.
+ * @param {object|null|undefined} options.indexingStatusFilter - Optional status scope from indexing query.
  * @param {object|null|undefined} options.actionParams - Action params from middleware context.
- * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ * @param {boolean} options.indexingQueryUsesWildcardLocale - Whether index config stores all locales.
  *
  * @returns {Promise<{documentId: string, preDeleteStrapiEntry: object|null, localeVariants: object[], localeCodesToRemove: string[]}>}
  */
@@ -69,31 +36,31 @@ const buildPreActionSnapshot = async ({
   contentTypeService,
   contentType,
   documentId,
-  statusFilter,
+  indexingStatusFilter,
   actionParams,
-  indexSyncUsesWildcardLocale,
+  indexingQueryUsesWildcardLocale,
 }) => {
   const preDeleteStrapiEntry = await contentTypeService.getEntry({
     contentType,
     documentId,
-    entriesQuery: { ...(statusFilter || {}) },
+    entriesQuery: { ...(indexingStatusFilter || {}) },
   })
 
   const shouldFetchLocaleVariants =
-    indexSyncUsesWildcardLocale && isWildcardLocale(actionParams?.locale)
+    indexingQueryUsesWildcardLocale && isWildcardLocale(actionParams?.locale)
   const localeVariants = shouldFetchLocaleVariants
     ? await contentTypeService.getEntries({
         contentType,
         fields: ['documentId', 'locale'],
         locale: '*',
-        ...(statusFilter || {}),
+        ...(indexingStatusFilter || {}),
         filters: {
           documentId,
         },
       })
     : []
 
-  const localeCodesToRemove = indexSyncUsesWildcardLocale
+  const localeCodesToRemove = indexingQueryUsesWildcardLocale
     ? resolveLocaleCodesToRemoveFromIndex({
         actionParams,
         preDeleteStrapiEntry,
@@ -116,9 +83,9 @@ const buildPreActionSnapshot = async ({
  * @param {string[]} options.documentIds - Target document ids.
  * @param {object} options.contentTypeService - Plugin content type service.
  * @param {string} options.contentType - Content type uid.
- * @param {object|null|undefined} options.statusFilter - Optional status scope from sync query.
+ * @param {object|null|undefined} options.indexingStatusFilter - Optional status scope from indexing query.
  * @param {object|null|undefined} options.actionParams - Action params from middleware context.
- * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ * @param {boolean} options.indexingQueryUsesWildcardLocale - Whether index config stores all locales.
  *
  * @returns {Promise<Array<{documentId: string, preDeleteStrapiEntry: object|null, localeVariants: object[], localeCodesToRemove: string[]}>>}
  */
@@ -126,9 +93,9 @@ const collectPreActionSnapshots = async ({
   documentIds,
   contentTypeService,
   contentType,
-  statusFilter,
+  indexingStatusFilter,
   actionParams,
-  indexSyncUsesWildcardLocale,
+  indexingQueryUsesWildcardLocale,
 }) => {
   return Promise.all(
     documentIds.map(documentId =>
@@ -136,9 +103,9 @@ const collectPreActionSnapshots = async ({
         contentTypeService,
         contentType,
         documentId,
-        statusFilter,
+        indexingStatusFilter,
         actionParams,
-        indexSyncUsesWildcardLocale,
+        indexingQueryUsesWildcardLocale,
       }),
     ),
   )
@@ -170,8 +137,8 @@ const normalizeLocaleCodes = localeCodes => {
  * @param {object} options - Delete dispatch options.
  * @param {object} options.meilisearch - Meilisearch plugin service.
  * @param {string} options.contentType - Content type uid.
- * @param {object} options.syncQuery - Plugin sync query configuration.
- * @param {boolean} options.indexSyncUsesWildcardLocale - Whether index config stores all locales.
+ * @param {object} options.indexingQuery - Plugin indexing query configuration.
+ * @param {boolean} options.indexingQueryUsesWildcardLocale - Whether index config stores all locales.
  * @param {{documentId: string, localeCodes?: string[]}[]} options.targets - Delete targets.
  *
  * @returns {Promise<void>}
@@ -179,8 +146,8 @@ const normalizeLocaleCodes = localeCodes => {
 const dispatchDeleteTargets = async ({
   meilisearch,
   contentType,
-  syncQuery,
-  indexSyncUsesWildcardLocale,
+  indexingQuery,
+  indexingQueryUsesWildcardLocale,
   targets,
 }) => {
   const validTargets = (targets || []).filter(
@@ -193,7 +160,7 @@ const dispatchDeleteTargets = async ({
 
   const groupedTargets = new Map()
   validTargets.forEach(target => {
-    const localeCodes = indexSyncUsesWildcardLocale
+    const localeCodes = indexingQueryUsesWildcardLocale
       ? normalizeLocaleCodes(target.localeCodes)
       : []
     const groupKey =
@@ -216,9 +183,9 @@ const dispatchDeleteTargets = async ({
     await meilisearch.deleteEntriesFromMeiliSearch({
       contentType,
       documentIds: [...new Set(group.documentIds)],
-      entriesQuery: syncQuery,
+      entriesQuery: indexingQuery,
       locales:
-        indexSyncUsesWildcardLocale && group.localeCodes.length > 0
+        indexingQueryUsesWildcardLocale && group.localeCodes.length > 0
           ? group.localeCodes
           : undefined,
     })
@@ -255,10 +222,12 @@ export default async function registerDocumentMiddleware({ strapi }) {
         'discardDraft',
       ]
 
-      const syncQuery = meilisearch.entriesQuery({ contentType })
-      const indexSyncUsesWildcardLocale = isWildcardLocale(syncQuery.locale)
-      const { status } = syncQuery || {}
-      const statusFilter =
+      const indexingQuery = meilisearch.entriesQuery({ contentType })
+      const indexingQueryUsesWildcardLocale = isWildcardLocale(
+        indexingQuery.locale,
+      )
+      const { status } = indexingQuery || {}
+      const indexingStatusFilter =
         typeof status === 'string' && status.length > 0 ? { status } : {}
       const isDraftIndex = status === 'draft'
       const isPublishedIndex = status === 'published'
@@ -266,28 +235,28 @@ export default async function registerDocumentMiddleware({ strapi }) {
       const shouldSkipDeleteAction =
         (ctx.action === 'unpublish' && isDraftIndex) ||
         (ctx.action === 'discardDraft' && isPublishedIndex)
-      const shouldTreatAsUpdateAction =
+      const shouldProcessAsRefetchFirstIndexingAction =
         updateActions.includes(ctx.action) ||
         (ctx.action === 'discardDraft' && isDraftIndex)
-      const shouldTreatAsDeleteAction =
+      const shouldProcessAsDeleteAction =
         deleteActions.includes(ctx.action) &&
-        !shouldTreatAsUpdateAction &&
+        !shouldProcessAsRefetchFirstIndexingAction &&
         !shouldSkipDeleteAction
 
       const preActionDocumentIds = resolveDocumentIdsFromActionParams(
         ctx?.params,
       )
       const shouldCollectPreActionSnapshots =
-        shouldTreatAsDeleteAction ||
+        shouldProcessAsDeleteAction ||
         (ctx.action === 'discardDraft' && isDraftIndex)
       const preActionSnapshots = shouldCollectPreActionSnapshots
         ? await collectPreActionSnapshots({
             documentIds: preActionDocumentIds,
             contentTypeService,
             contentType,
-            statusFilter,
+            indexingStatusFilter,
             actionParams: ctx?.params,
-            indexSyncUsesWildcardLocale,
+            indexingQueryUsesWildcardLocale,
           })
         : []
       const preActionSnapshotsByDocumentId = new Map(
@@ -302,77 +271,80 @@ export default async function registerDocumentMiddleware({ strapi }) {
         preActionSnapshots,
       })
 
-      if (shouldTreatAsUpdateAction && documentIds.length > 0) {
-        const resultCandidates = extractStrapiEntryCandidates(result)
-        const entriesToUpdate = []
+      if (shouldProcessAsRefetchFirstIndexingAction && documentIds.length > 0) {
+        const actionResultCandidates = extractStrapiEntryCandidates(result)
+        const entriesToIndex = []
         const deleteTargets = []
 
         for (const documentId of documentIds) {
           if (ctx.action === 'discardDraft' && isDraftIndex) {
+            // discardDraft in draft indexes remains snapshot-driven: refetch/update
+            // draft entries, then remove locales that existed pre-action but not after.
             const preActionSnapshot =
               preActionSnapshotsByDocumentId.get(documentId) || null
             const actionLocale = getActionLocale(ctx?.params)
             const shouldLoadDraftEntriesAcrossLocales =
-              indexSyncUsesWildcardLocale && isWildcardLocale(actionLocale)
+              indexingQueryUsesWildcardLocale && isWildcardLocale(actionLocale)
 
-            const draftEntriesFromResult =
+            const draftEntriesFromActionResult =
               selectDraftEntriesForDiscardDraftResult({
-                resultCandidates,
+                resultCandidates: actionResultCandidates,
                 documentId,
                 actionParams: ctx?.params,
               })
 
-            let draftEntriesToUpdate = shouldLoadDraftEntriesAcrossLocales
+            let draftEntriesToIndex = shouldLoadDraftEntriesAcrossLocales
               ? await contentTypeService.getEntries({
                   contentType,
                   locale: '*',
-                  ...statusFilter,
+                  ...indexingStatusFilter,
                   filters: {
                     documentId,
                   },
                 })
-              : draftEntriesFromResult
+              : draftEntriesFromActionResult
 
-            draftEntriesToUpdate = (draftEntriesToUpdate || []).filter(
+            draftEntriesToIndex = (draftEntriesToIndex || []).filter(
               entry => entry && !isPublishedStrapiEntry(entry),
             )
 
             if (
-              draftEntriesToUpdate.length === 0 &&
+              draftEntriesToIndex.length === 0 &&
               shouldLoadDraftEntriesAcrossLocales
             ) {
-              draftEntriesToUpdate = draftEntriesFromResult
+              draftEntriesToIndex = draftEntriesFromActionResult
             }
 
             if (
-              draftEntriesToUpdate.length === 0 &&
+              draftEntriesToIndex.length === 0 &&
               !shouldLoadDraftEntriesAcrossLocales
             ) {
-              const fallbackStrapiEntry = await getStrapiEntryAfterTransaction({
-                contentTypeService,
-                contentType,
-                documentId,
-                syncQuery: resolveLocaleScopedReadQuery({
-                  syncQuery,
-                  actionParams: ctx?.params,
-                }),
-              })
+              const refetchedDraftEntry =
+                await fetchSingleEntryAfterTransaction({
+                  contentTypeService,
+                  contentType,
+                  documentId,
+                  indexingQuery: resolveLocaleScopedRefetchQuery({
+                    indexingQuery,
+                    actionParams: ctx?.params,
+                  }),
+                })
 
               if (
-                fallbackStrapiEntry &&
-                !isPublishedStrapiEntry(fallbackStrapiEntry)
+                refetchedDraftEntry &&
+                !isPublishedStrapiEntry(refetchedDraftEntry)
               ) {
-                draftEntriesToUpdate = [fallbackStrapiEntry]
+                draftEntriesToIndex = [refetchedDraftEntry]
               }
             }
 
-            if (draftEntriesToUpdate.length > 0) {
-              const normalizedDraftEntries = draftEntriesToUpdate.map(entry =>
+            if (draftEntriesToIndex.length > 0) {
+              const normalizedDraftEntries = draftEntriesToIndex.map(entry =>
                 entry.documentId === documentId
                   ? entry
                   : { ...entry, documentId },
               )
-              entriesToUpdate.push(...normalizedDraftEntries)
+              entriesToIndex.push(...normalizedDraftEntries)
             }
 
             const preActionLocaleCodes = resolveLocaleCodesToRemoveFromIndex({
@@ -382,7 +354,7 @@ export default async function registerDocumentMiddleware({ strapi }) {
               localeVariants: preActionSnapshot?.localeVariants || [],
             })
             const remainingLocaleCodes =
-              collectLocaleCodesFromEntries(draftEntriesToUpdate)
+              collectLocaleCodesFromEntries(draftEntriesToIndex)
             const localeCodesToDelete = preActionLocaleCodes.filter(
               localeCode => !remainingLocaleCodes.includes(localeCode),
             )
@@ -397,57 +369,57 @@ export default async function registerDocumentMiddleware({ strapi }) {
             continue
           }
 
-          let entriesForDocument = []
-          const publishedEntriesFromWildcardPublish =
-            selectPublishedEntriesForWildcardPublish({
-              resultCandidates,
-              documentId,
-              actionParams: ctx?.params,
-              syncQuery,
-            })
-          if (publishedEntriesFromWildcardPublish.length > 0) {
-            entriesForDocument = publishedEntriesFromWildcardPublish
-          }
-
-          let strapiEntry = selectStrapiEntryToIndexFromResult({
-            resultCandidates,
-            documentId,
-            syncQuery,
+          let refetchedEntriesForDocument = []
+          const actionLocale = getActionLocale(ctx?.params)
+          const localeScopedRefetchQuery = resolveLocaleScopedRefetchQuery({
+            indexingQuery,
             actionParams: ctx?.params,
           })
+          const indexingQueryStoresDrafts = indexingQuery?.status === 'draft'
+          const shouldRefetchAllLocales =
+            indexingQueryUsesWildcardLocale &&
+            isWildcardLocale(actionLocale) &&
+            isWildcardLocale(indexingQuery?.locale) &&
+            !indexingQueryStoresDrafts
 
-          if (entriesForDocument.length === 0 && !strapiEntry) {
-            strapiEntry = await getStrapiEntryAfterTransaction({
-              contentTypeService,
-              contentType,
-              documentId,
-              syncQuery: resolveLocaleScopedReadQuery({
-                syncQuery,
-                actionParams: ctx?.params,
-              }),
-            })
+          if (shouldRefetchAllLocales) {
+            refetchedEntriesForDocument =
+              await fetchWildcardLocaleEntriesForIndexing({
+                contentTypeService,
+                contentType,
+                documentId,
+                indexingQuery,
+              })
+          } else {
+            const refetchedStrapiEntry = await fetchSingleEntryAfterTransaction(
+              {
+                contentTypeService,
+                contentType,
+                documentId,
+                indexingQuery: localeScopedRefetchQuery,
+              },
+            )
+
+            if (refetchedStrapiEntry) {
+              refetchedEntriesForDocument = [refetchedStrapiEntry]
+            }
           }
 
-          if (entriesForDocument.length === 0 && strapiEntry) {
-            entriesForDocument = [strapiEntry]
-          }
-
-          if (entriesForDocument.length > 0) {
-            const normalizedEntries = entriesForDocument.map(entry =>
+          if (refetchedEntriesForDocument.length > 0) {
+            const normalizedEntries = refetchedEntriesForDocument.map(entry =>
               entry.documentId === documentId
                 ? entry
                 : { ...entry, documentId },
             )
-            entriesToUpdate.push(...normalizedEntries)
+            entriesToIndex.push(...normalizedEntries)
           } else if (ctx.action === 'create' || ctx.action === 'publish') {
-            const createPublishLocaleCodesToRemove = indexSyncUsesWildcardLocale
-              ? resolveLocaleCodesToRemoveFromActionResult({
-                  actionParams: ctx?.params,
-                  resultCandidates,
-                  result,
-                  documentId,
-                })
-              : []
+            const createPublishLocaleCodesToRemove =
+              indexingQueryUsesWildcardLocale &&
+              typeof localeScopedRefetchQuery?.locale === 'string' &&
+              localeScopedRefetchQuery.locale.length > 0 &&
+              !isWildcardLocale(localeScopedRefetchQuery.locale)
+                ? [localeScopedRefetchQuery.locale]
+                : []
 
             deleteTargets.push({
               documentId,
@@ -455,15 +427,15 @@ export default async function registerDocumentMiddleware({ strapi }) {
             })
           } else {
             strapi.log.info(
-              `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry in action result`,
+              `Meilisearch document middleware skipped indexing ${contentType} documentId=${documentId} for action ${ctx.action}: no indexable Strapi entry after refetch`,
             )
           }
         }
 
-        if (entriesToUpdate.length > 0) {
+        if (entriesToIndex.length > 0) {
           await meilisearch.updateEntriesInMeilisearch({
             contentType,
-            entries: entriesToUpdate,
+            entries: entriesToIndex,
           })
         }
 
@@ -471,19 +443,19 @@ export default async function registerDocumentMiddleware({ strapi }) {
           await dispatchDeleteTargets({
             meilisearch,
             contentType,
-            syncQuery,
-            indexSyncUsesWildcardLocale,
+            indexingQuery,
+            indexingQueryUsesWildcardLocale,
             targets: deleteTargets,
           })
         }
-      } else if (shouldTreatAsDeleteAction) {
+      } else if (shouldProcessAsDeleteAction) {
         if (documentIds.length > 0) {
           const deleteTargets = documentIds.map(documentId => {
             const preActionSnapshot =
               preActionSnapshotsByDocumentId.get(documentId) || null
             return {
               documentId,
-              localeCodes: indexSyncUsesWildcardLocale
+              localeCodes: indexingQueryUsesWildcardLocale
                 ? preActionSnapshot?.localeCodesToRemove || []
                 : [],
             }
@@ -495,8 +467,8 @@ export default async function registerDocumentMiddleware({ strapi }) {
           await dispatchDeleteTargets({
             meilisearch,
             contentType,
-            syncQuery,
-            indexSyncUsesWildcardLocale,
+            indexingQuery,
+            indexingQueryUsesWildcardLocale,
             targets: deleteTargets,
           })
         } else {

--- a/server/src/services/document-middleware/locale-resolution.js
+++ b/server/src/services/document-middleware/locale-resolution.js
@@ -115,48 +115,6 @@ export const resolveLocaleCodesToRemoveFromIndex = ({
 }
 
 /**
- * Resolve locales to remove for create/publish fallback deletes on wildcard indexes.
- *
- * @param {object} options - Action-result locale removal options.
- * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
- * @param {{data: object, source: string}[]|null|undefined} options.resultCandidates - Candidate Strapi entries from action result.
- * @param {object|null|undefined} options.result - Raw action result.
- * @param {string} options.documentId - Target Strapi document id.
- *
- * @returns {string[]} Locales to remove from Meilisearch.
- */
-export const resolveLocaleCodesToRemoveFromActionResult = ({
-  actionParams,
-  resultCandidates,
-  result,
-  documentId,
-}) => {
-  const entriesForDocument = (resultCandidates || [])
-    .map(candidate => candidate?.data)
-    .filter(entry => entry?.documentId === documentId)
-
-  const localeVariants = entriesForDocument
-    .filter(
-      entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
-    )
-    .map(entry => ({ documentId: entry.documentId, locale: entry.locale }))
-
-  const preDeleteStrapiEntry =
-    entriesForDocument.find(
-      entry => typeof entry?.locale === 'string' && entry.locale.length > 0,
-    ) ??
-    (typeof result?.locale === 'string' && result.locale.length > 0
-      ? result
-      : (entriesForDocument[0] ?? null))
-
-  return resolveLocaleCodesToRemoveFromIndex({
-    actionParams,
-    preDeleteStrapiEntry,
-    localeVariants,
-  })
-}
-
-/**
  * Build a unique list of locale codes from Strapi entries.
  *
  * @param {object[]|null|undefined} entries - Strapi entries with optional locale fields.

--- a/server/src/services/document-middleware/locale-resolution.js
+++ b/server/src/services/document-middleware/locale-resolution.js
@@ -19,27 +19,30 @@ export const getActionLocale = actionParams => {
  *
  * Priority:
  * 1. Concrete action locale in middleware params.
- * 2. Concrete locale from Meilisearch sync query config.
+ * 2. Concrete locale from Meilisearch indexing query config.
  *
  * @param {object} options - Locale resolution options.
- * @param {object|null|undefined} options.syncQuery - Plugin sync query configuration.
+ * @param {object|null|undefined} options.indexingQuery - Plugin indexing query configuration.
  * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
  *
  * @returns {string|null} Preferred concrete locale when one is available.
  */
-export const resolvePreferredConcreteLocale = ({ syncQuery, actionParams }) => {
+export const resolvePreferredConcreteLocale = ({
+  indexingQuery,
+  actionParams,
+}) => {
   const actionLocale = getActionLocale(actionParams)
   if (actionLocale && !isWildcardLocale(actionLocale)) {
     return actionLocale
   }
 
-  const syncLocale =
-    typeof syncQuery?.locale === 'string' && syncQuery.locale.length > 0
-      ? syncQuery.locale
+  const indexingLocale =
+    typeof indexingQuery?.locale === 'string' && indexingQuery.locale.length > 0
+      ? indexingQuery.locale
       : null
 
-  if (syncLocale && !isWildcardLocale(syncLocale)) {
-    return syncLocale
+  if (indexingLocale && !isWildcardLocale(indexingLocale)) {
+    return indexingLocale
   }
 
   return null
@@ -52,14 +55,17 @@ export const resolvePreferredConcreteLocale = ({ syncQuery, actionParams }) => {
  * keep every existing query option and only override `locale` with the action locale.
  *
  * @param {object} options - Query resolution options.
- * @param {object|null|undefined} options.syncQuery - Base query from Meilisearch config.
+ * @param {object|null|undefined} options.indexingQuery - Base query from Meilisearch config.
  * @param {object|null|undefined} options.actionParams - Action params from document middleware context.
  *
  * @returns {object} Query passed to `contentTypeService.getEntry`.
  */
-export const resolveLocaleScopedReadQuery = ({ syncQuery, actionParams }) => {
+export const resolveLocaleScopedRefetchQuery = ({
+  indexingQuery,
+  actionParams,
+}) => {
   const actionLocale = getActionLocale(actionParams)
-  const baseQuery = { ...(syncQuery || {}) }
+  const baseQuery = { ...(indexingQuery || {}) }
 
   if (!isWildcardLocale(baseQuery.locale) || actionLocale == null) {
     return baseQuery


### PR DESCRIPTION
# Description

## Why

Fixes #1139 

## How

- Refetch-first indexing is now enforced for `create` / `update` / `publish` in `server/src/services/document-middleware/index.js`.
- Live sync no longer indexes raw action-result payloads for those actions; it indexes post-transaction refetch results driven by `entriesQuery`.
- Locale behavior is explicit and aligned with accepted defaults:
  - concrete action locale + wildcard query -> single-locale refetch,
  - wildcard action locale + wildcard query -> all-locale refetch,
  - concrete query locale remains authoritative.
- `discardDraft` remains explicit/snapshot-driven as a separate branch (kept intact).
- Extracted refetch helpers into new `server/src/services/document-middleware/entry-refetch.js` for clearer structure/naming.

Also renamed some variables and edited comments to make behavior more explicit.

## Checklist

- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) guide
- [ ] ⚠️⚠️ **I have run Cypress E2E tests locally** ⚠️⚠️

> [!warning]
> Cypress tests are currently flaky in CI. Until they are fixed, we require that you paste your local Cypress logs to encourage local testing.

**Output from `yarn cypress run`:**

```
# Paste cypress run output here
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes issue `#1139` where update hooks were ignoring the `entriesQuery` configuration and incorrectly indexing relations. The solution implements a refetch-first indexing strategy for `create`, `update`, and `publish` actions in the document-middleware service, ensuring that entries are refetched according to the configured `entriesQuery` before indexing.

## Key Changes

### Refetch-First Indexing Strategy
- Live sync no longer indexes raw action-result payloads for `create`, `update`, and `publish` actions
- Instead, these actions now refetch entries post-transaction using the configured `entriesQuery` and index the refetched results
- The `discardDraft` action remains snapshot-driven for backward compatibility

### Locale Behavior Alignment
- Concrete action locale + wildcard query results in single-locale refetch
- Wildcard action locale + wildcard query results in all-locale refetch
- Concrete query locale remains authoritative for locale resolution

### Code Structure Improvements
- Extracted refetch helper functions into new `server/src/services/document-middleware/entry-refetch.js`:
  - `fetchSingleEntryAfterTransaction`: Defers single entry fetch to next event-loop tick, merging `indexingQuery` into fetch parameters
  - `fetchWildcardLocaleEntriesForIndexing`: Fetches all locale variants for a document via wildcard locale queries

### Function Signature Updates
- `selectStrapiEntryToIndexFromResult` and `selectPublishedEntriesForWildcardPublish` now accept `indexingQuery` parameter (replacing `syncQuery`)
- `resolvePreferredConcreteLocale` updated to resolve locale from `indexingQuery` instead of `syncQuery`
- Introduced new `resolveLocaleScopedRefetchQuery` helper replacing the removed `resolveLocaleScopedReadQuery`
- Removed `resolveLocaleCodesToRemoveFromActionResult` in favor of refetch-based locale tracking

### Middleware Logic Refactoring
- Derives `indexingQuery`, `indexingQueryUsesWildcardLocale`, and `indexingStatusFilter` from configuration
- Pre-action snapshots now filtered by `indexingStatusFilter` for draft-aware operations
- `dispatchDeleteTargets` refactored to use `indexingQuery` for Meilisearch delete operations with appropriate locale scoping
- When refetch returns `null`, locale-specific deletions are scheduled for `create`/`publish` actions
- Wildcard-locale refetch behavior consolidated to avoid redundant delete operations

## Test Coverage
- Updated test assertions to validate refetch-first behavior
- Added coverage for "refetch-first indexing defaults" across all relevant actions
- New tests for wildcard-locale refetch scenarios
- Added tests for "fallback delete" scenarios when refetch returns `null` and no concrete locale is available
- Renamed discardDraft stale-locale test for clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->